### PR TITLE
Using default error_handler related to frontend

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -72,7 +72,7 @@ class Configuration implements ConfigurationInterface
                             ->arrayNode('disallowed_mimetypes')
                                 ->prototype('scalar')->end()
                             ->end()
-                            ->scalarNode('error_handler')->defaultValue('oneup_uploader.error_handler.noop')->end()
+                            ->scalarNode('error_handler')->defaultNull()->end()
                             ->scalarNode('max_size')
                                 ->defaultValue(\PHP_INT_MAX)
                                 ->info('Set max_size to -1 for gracefully downgrade this number to the systems max upload size.')

--- a/DependencyInjection/OneupUploaderExtension.php
+++ b/DependencyInjection/OneupUploaderExtension.php
@@ -121,7 +121,9 @@ class OneupUploaderExtension extends Extension
                     throw new ServiceNotFoundException('Empty controller class or name. If you really want to use a custom frontend implementation, be sure to provide a class and a name.');
             }
 
-            $errorHandler = new Reference($mapping['error_handler']);
+            $errorHandler = is_null($mapping['error_handler']) ?
+                new Reference('oneup_uploader.error_handler.'.$mapping['frontend']) :
+                new Reference($mapping['error_handler']);
 
             // create controllers based on mapping
             $container

--- a/Resources/config/errorhandler.xml
+++ b/Resources/config/errorhandler.xml
@@ -10,7 +10,14 @@
 
            <services>
                <service id="oneup_uploader.error_handler.noop" class="%oneup_uploader.error_handler.noop.class%" public="false" />
+               <service id="oneup_uploader.error_handler.fineuploader" class="%oneup_uploader.error_handler.noop.class%" public="false" />
                <service id="oneup_uploader.error_handler.blueimp" class="%oneup_uploader.error_handler.blueimp.class%" public="false" />
+               <service id="oneup_uploader.error_handler.uploadify" class="%oneup_uploader.error_handler.noop.class%" public="false" />
+               <service id="oneup_uploader.error_handler.yui3" class="%oneup_uploader.error_handler.noop.class%" public="false" />
+               <service id="oneup_uploader.error_handler.fancyupload" class="%oneup_uploader.error_handler.noop.class%" public="false" />
+               <service id="oneup_uploader.error_handler.mooupload" class="%oneup_uploader.error_handler.noop.class%" public="false" />
+               <service id="oneup_uploader.error_handler.plupload" class="%oneup_uploader.error_handler.noop.class%" public="false" />
+               <service id="oneup_uploader.error_handler.custom" class="%oneup_uploader.error_handler.noop.class%" public="false" />
            </services>
 
 </container>


### PR DESCRIPTION
Till now NoopErrorHandler was used as default for any frontend
Therefore for use bultin BlueimpErrorHandler for example we have
to manually configure it
