### PR TITLE
Let blueimp return a text/plain response to old browsers

### DIFF
--- a/Controller/BlueimpController.php
+++ b/Controller/BlueimpController.php
@@ -30,7 +30,7 @@ class BlueimpController extends AbstractChunkedController
             }
         }
 
-        return new JsonResponse($response->assemble());
+        return $this->createSupportedJsonResponse($response->assemble());
     }
 
     public function progress()
@@ -51,7 +51,7 @@ class BlueimpController extends AbstractChunkedController
             'total' => $value['content_length']
         );
 
-        return new JsonResponse($progress);
+        return $this->createSupportedJsonResponse($progress);
     }
 
     protected function parseChunkedRequest(Request $request)
@@ -82,5 +82,27 @@ class BlueimpController extends AbstractChunkedController
         $orig  = $attachmentName;
 
         return array($last, $uuid, $index, $orig);
+    }
+
+    /**
+     * Creates and returns a JsonResponse with the given data.
+     *
+     * On top of that, if the client does not support the application/json type,
+     * then the content type of the response will be set to text/plain instead.
+     *
+     * @param mixed $data
+     *
+     * @return JsonResponse
+     */
+    private function createSupportedJsonResponse($data)
+    {
+        $request = $this->container->get('request');
+        $response = new JsonResponse($data);
+        $response->headers->set('Vary', 'Accept');
+        if (!in_array('application/json', $request->getAcceptableContentTypes())) {
+            $response->headers->set('Content-type', 'text/plain');
+        }
+
+        return $response;
     }
 }

--- a/Tests/Controller/AbstractControllerTest.php
+++ b/Tests/Controller/AbstractControllerTest.php
@@ -63,7 +63,7 @@ abstract class AbstractControllerTest extends WebTestCase
         $client = $this->client;
         $endpoint = $this->helper->endpoint($this->getConfigKey());
 
-        $client->request('POST', $endpoint);
+        $client->request('POST', $endpoint, array(), array(), array('HTTP_ACCEPT' => 'application/json'));
         $response = $client->getResponse();
 
         $this->assertTrue($response->isSuccessful());

--- a/Tests/Controller/BlueimpTest.php
+++ b/Tests/Controller/BlueimpTest.php
@@ -16,7 +16,7 @@ class BlueimpTest extends AbstractUploadTest
         $client = $this->client;
         $endpoint = $this->helper->endpoint($this->getConfigKey());
 
-        $client->request('POST', $endpoint, $this->getRequestParameters(), $this->getRequestFile());
+        $client->request('POST', $endpoint, $this->getRequestParameters(), $this->getRequestFile(), array('HTTP_ACCEPT' => 'application/json'));
         $response = $client->getResponse();
 
         $this->assertTrue($response->isSuccessful());
@@ -28,6 +28,20 @@ class BlueimpTest extends AbstractUploadTest
             $this->assertTrue($file->isReadable());
             $this->assertEquals(128, $file->getSize());
         }
+    }
+
+    public function testResponseForOldBrowsers()
+    {
+        $client = $this->client;
+        $endpoint = $this->helper->endpoint($this->getConfigKey());
+
+        $client->request('POST', $endpoint, $this->getRequestParameters(), $this->getRequestFile());
+        $response = $client->getResponse();
+
+        $this->assertTrue($response->isSuccessful());
+        $this->assertEquals($response->headers->get('Content-Type'), 'text/plain; charset=UTF-8');
+        $this->assertCount(1, $this->getUploadedFiles());
+
     }
 
     public function testEvents()

--- a/Tests/Controller/BlueimpValidationTest.php
+++ b/Tests/Controller/BlueimpValidationTest.php
@@ -15,7 +15,7 @@ class BlueimpValidationTest extends AbstractValidationTest
         $client = $this->client;
         $endpoint = $this->helper->endpoint($this->getConfigKey());
 
-        $client->request('POST', $endpoint, $this->getRequestParameters(), $this->getOversizedFile());
+        $client->request('POST', $endpoint, $this->getRequestParameters(), $this->getOversizedFile(), array('HTTP_ACCEPT' => 'application/json'));
         $response = $client->getResponse();
 
         //$this->assertTrue($response->isNotSuccessful());
@@ -29,7 +29,7 @@ class BlueimpValidationTest extends AbstractValidationTest
         $client = $this->client;
         $endpoint = $this->helper->endpoint($this->getConfigKey());
 
-        $client->request('POST', $endpoint, $this->getRequestParameters(), $this->getFileWithCorrectExtension());
+        $client->request('POST', $endpoint, $this->getRequestParameters(), $this->getFileWithCorrectExtension(), array('HTTP_ACCEPT' => 'application/json'));
         $response = $client->getResponse();
 
         $this->assertTrue($response->isSuccessful());
@@ -67,7 +67,7 @@ class BlueimpValidationTest extends AbstractValidationTest
         $client = $this->client;
         $endpoint = $this->helper->endpoint($this->getConfigKey());
 
-        $client->request('POST', $endpoint, $this->getRequestParameters(), $this->getFileWithIncorrectExtension());
+        $client->request('POST', $endpoint, $this->getRequestParameters(), $this->getFileWithIncorrectExtension(), array('HTTP_ACCEPT' => 'application/json'));
         $response = $client->getResponse();
 
         //$this->assertTrue($response->isNotSuccessful());
@@ -81,7 +81,7 @@ class BlueimpValidationTest extends AbstractValidationTest
         $client = $this->client;
         $endpoint = $this->helper->endpoint($this->getConfigKey());
 
-        $client->request('POST', $endpoint, $this->getRequestParameters(), $this->getFileWithCorrectMimeType());
+        $client->request('POST', $endpoint, $this->getRequestParameters(), $this->getFileWithCorrectMimeType(), array('HTTP_ACCEPT' => 'application/json'));
         $response = $client->getResponse();
 
         $this->assertTrue($response->isSuccessful());
@@ -103,7 +103,7 @@ class BlueimpValidationTest extends AbstractValidationTest
         $client = $this->client;
         $endpoint = $this->helper->endpoint($this->getConfigKey());
 
-        $client->request('POST', $endpoint, $this->getRequestParameters(), $this->getFileWithIncorrectMimeType());
+        $client->request('POST', $endpoint, $this->getRequestParameters(), $this->getFileWithIncorrectMimeType(), array('HTTP_ACCEPT' => 'application/json'));
         $response = $client->getResponse();
 
         //$this->assertTrue($response->isNotSuccessful());


### PR DESCRIPTION
Currently, the blueimp uploader does not work on old browsers like Internet Explorer 9. A download dialog will popup for the JSON response.

The reason is mentioned in the plugin documentation:

> Iframe based uploads require a Content-type of text/plain or text/html for the JSON response - they will show an undesired download dialog if the iframe response is set to application/json.

This pull request incorporates the suggested ["Content-Negotiotation" workaround](https://github.com/blueimp/jQuery-File-Upload/wiki/Setup#content-type-negotiation) from the plugin documentation.

If the client does not send the HTTP_ACCEPT header including application/json, then a text/plain response will be sent back. The tests have been modified accordingly. A new test has been added to check the content-type in case the HTTP_ACCEPT header does not include application/json.

I hope this pull request will be merged upstream. It would make deploying my own application with the fix easier. :) By the way, thanks for your work on this bundle! It is very solid and has saved me a lot of time.
