### PR TITLE
Any ideas for scaling?

### DIFF
--- a/DependencyInjection/OneupUploaderExtension.php
+++ b/DependencyInjection/OneupUploaderExtension.php
@@ -63,12 +63,6 @@ class OneupUploaderExtension extends Extension
 
     protected function processMapping($key, &$mapping)
     {
-        if ($this->config['chunks']['storage']['type'] === 'gaufrette') {
-            if ($mapping['storage']['type'] !== 'gaufrette') {
-                throw new \InvalidArgumentException('If you use a gaufrette based chunk storage, you may only use gaufrette based storages too.');
-            }
-        }
-
         $mapping['max_size'] = $mapping['max_size'] < 0 ?
             $this->getMaxUploadSize($mapping['max_size']) :
             $mapping['max_size']

--- a/Resources/doc/chunked_uploads.md
+++ b/Resources/doc/chunked_uploads.md
@@ -69,7 +69,7 @@ only the Local filesystem is capable of streaming directly.
 The chunks will be read directly from the temporary directory and appended to the already existing part on the given filesystem,
 resulting in only one single read and one single write operation.
 
-> :exclamation: If you use a gaufrette filesystem as chunk storage, you may only use gaufrette filesystems in your mappings too!
+> :exclamation: Do not use a Gaufrette filesystem for the chunk storage and a local filesystem for the mapping. This is not possible to check during container setup and will throw unexpected errors at runtime!
 
 You can achieve the biggest improvement if you use the same filesystem as your storage. If you do so, the assembled
 file only has to be moved out of the chunk directory, which takes no time on a local filesystem.


### PR DESCRIPTION
I was wondering if you have any idea about putting behind a load-balancer. (Given that we avoid trying to route requests from the same client to the same machine)

What I am wondering about is chunked uploads would only work if the temporary place where the chunks (chunk since one of our previous discussion) is stored in a shared place.
But then again, it would mean the latest-chunk is uploaded to the server, the remote file read, the latest-chunk written to it, and saved to the shared place again so the next request can access it from a possibly different server and then moved to it's final place. Sounds pretty un-effective to me.

Do you have any ideas how we could improve this, or if my I miss something? 
