### PR TITLE
PostUploadEvent extended with generated filename

### DIFF
--- a/Controller/AbstractController.php
+++ b/Controller/AbstractController.php
@@ -116,7 +116,7 @@ abstract class AbstractController
         // perform the real upload
         $uploaded = $this->storage->upload($file, $name);
 
-        $this->dispatchPostEvents($uploaded, $response, $request);
+        $this->dispatchPostEvents($uploaded, $name, $response, $request);
     }
 
     /**
@@ -144,12 +144,12 @@ abstract class AbstractController
      *  @param response A response object.
      *  @param request The request object.
      */
-    protected function dispatchPostEvents($uploaded, ResponseInterface $response, Request $request)
+    protected function dispatchPostEvents($uploaded, $generatedFileName, ResponseInterface $response, Request $request)
     {
         $dispatcher = $this->container->get('event_dispatcher');
 
         // dispatch post upload event (both the specific and the general)
-        $postUploadEvent = new PostUploadEvent($uploaded, $response, $request, $this->type, $this->config);
+        $postUploadEvent = new PostUploadEvent($uploaded, $generatedFileName, $response, $request, $this->type, $this->config);
         $dispatcher->dispatch(UploadEvents::POST_UPLOAD, $postUploadEvent);
         $dispatcher->dispatch(sprintf('%s.%s', UploadEvents::POST_UPLOAD, $this->type), $postUploadEvent);
 

--- a/Event/PostUploadEvent.php
+++ b/Event/PostUploadEvent.php
@@ -13,10 +13,12 @@ class PostUploadEvent extends Event
     protected $type;
     protected $response;
     protected $config;
+    protected $generatedFileName;
 
-    public function __construct($file, ResponseInterface $response, Request $request, $type, array $config)
+    public function __construct($file, $generatedFileName, ResponseInterface $response, Request $request, $type, array $config)
     {
         $this->file = $file;
+        $this->generatedFileName = $generatedFileName;
         $this->request = $request;
         $this->response = $response;
         $this->type = $type;
@@ -47,4 +49,15 @@ class PostUploadEvent extends Event
     {
         return $this->config;
     }
+
+	public function getGeneratedFileName() {
+		return $this->generatedFileName;
+	}
+	
+	public function setGeneratedFileName($generatedFileName) {
+		$this->generatedFileName = $generatedFileName;
+		return $this;
+	}
+	
+    
 }


### PR DESCRIPTION
I extended the PostUploadEvent with information about generated file on server side. So the own UploadListener implemented by user can check and use generated file references.
