### PR TITLE
use the stream wrapper prefix when available

### DIFF
--- a/Uploader/Chunk/Storage/GaufretteStorage.php
+++ b/Uploader/Chunk/Storage/GaufretteStorage.php
@@ -169,4 +169,9 @@ class GaufretteStorage extends StreamManager implements ChunkStorageInterface
     {
         return $this->filesystem;
     }
+
+    public function getStreamWrapperPrefix()
+    {
+        return $this->streamWrapperPrefix;
+    }
 }

--- a/Uploader/Storage/GaufretteOrphanageStorage.php
+++ b/Uploader/Storage/GaufretteOrphanageStorage.php
@@ -26,9 +26,11 @@ class GaufretteOrphanageStorage extends GaufretteStorage implements OrphanageSto
      */
     public function __construct(StorageInterface $storage, SessionInterface $session, GaufretteChunkStorage $chunkStorage, $config, $type)
     {
-        // initiate the storage on the chunk storage's filesystem
-        // the prefix and stream wrapper are unnecessary.
-        parent::__construct($chunkStorage->getFilesystem(), $chunkStorage->bufferSize, null, null);
+        /*
+         * initiate the storage on the chunk storage's filesystem
+         * the stream wrapper is useful for metadata.
+         */
+        parent::__construct($chunkStorage->getFilesystem(), $chunkStorage->bufferSize, $chunkStorage->getStreamWrapperPrefix());
 
         $this->storage = $storage;
         $this->chunkStorage = $chunkStorage;


### PR DESCRIPTION
This will make the metadata available for files in a gaufrette orphanage file storage, also fixes the number of arguments for the parent::__construct call.
