### PR TITLE
[Doc] Add Exception about the ValidationEvent

### DIFF
--- a/Resources/doc/response.md
+++ b/Resources/doc/response.md
@@ -1,7 +1,7 @@
 Return custom data to the Frontend
 ==================================
 
-There are some use cases where you need custom data to be returned to the frontend. For example the id of a generated Doctrine Entity or the like. To cover this, you can use `UploaderResponse` passed through all `Events`.
+There are some use cases where you need custom data to be returned to the frontend. For example the id of a generated Doctrine Entity or the like. To cover this, you can use `UploaderResponse` passed through all `Events` (except the `ValidationEvent`).
 
 ```php
 namespace Acme\HelloBundle\EventListener;


### PR DESCRIPTION
It does not contain the response. (Is there any reason by the way)?
It would have made sense to me to be able to set an error in the response in the validationEvent.
