### PR TITLE
ErrorHandler for Dropzone

### DIFF
--- a/Controller/AbstractController.php
+++ b/Controller/AbstractController.php
@@ -183,13 +183,14 @@ abstract class AbstractController
      * then the content type of the response will be set to text/plain instead.
      *
      * @param mixed $data
+     * @param int $statusCode
      *
      * @return JsonResponse
      */
-    protected function createSupportedJsonResponse($data)
+    protected function createSupportedJsonResponse($data, $statusCode = 200)
     {
         $request = $this->container->get('request');
-        $response = new JsonResponse($data);
+        $response = new JsonResponse($data, $statusCode);
         $response->headers->set('Vary', 'Accept');
 
         if (!in_array('application/json', $request->getAcceptableContentTypes())) {

--- a/Controller/DropzoneController.php
+++ b/Controller/DropzoneController.php
@@ -14,15 +14,16 @@ class DropzoneController extends AbstractController
         $request = $this->container->get('request');
         $response = new EmptyResponse();
         $files = $this->getFiles($request->files);
-
+        $statusCode = 200;
         foreach ($files as $file) {
             try {
                 $this->handleUpload($file, $response, $request);
             } catch (UploadException $e) {
+                $statusCode = 500; //Dropzone displays error if HTTP response is 40x or 50x
                 $this->errorHandler->addException($response, $e);
             }
         }
 
-        return $this->createSupportedJsonResponse($response->assemble());
+        return $this->createSupportedJsonResponse($response->assemble(), $statusCode);
     }
 }

--- a/Resources/config/errorhandler.xml
+++ b/Resources/config/errorhandler.xml
@@ -6,6 +6,7 @@
            <parameters>
                <parameter key="oneup_uploader.error_handler.noop.class">Oneup\UploaderBundle\Uploader\ErrorHandler\NoopErrorHandler</parameter>
                <parameter key="oneup_uploader.error_handler.blueimp.class">Oneup\UploaderBundle\Uploader\ErrorHandler\BlueimpErrorHandler</parameter>
+               <parameter key="oneup_uploader.error_handler.dropzone.class">Oneup\UploaderBundle\Uploader\ErrorHandler\DropzoneErrorHandler</parameter>
            </parameters>
 
            <services>
@@ -17,7 +18,7 @@
                <service id="oneup_uploader.error_handler.fancyupload" class="%oneup_uploader.error_handler.noop.class%" public="false" />
                <service id="oneup_uploader.error_handler.mooupload" class="%oneup_uploader.error_handler.noop.class%" public="false" />
                <service id="oneup_uploader.error_handler.plupload" class="%oneup_uploader.error_handler.noop.class%" public="false" />
-               <service id="oneup_uploader.error_handler.dropzone" class="%oneup_uploader.error_handler.noop.class%" public="false" />
+               <service id="oneup_uploader.error_handler.dropzone" class="%oneup_uploader.error_handler.dropzone.class%" public="false" />
                <service id="oneup_uploader.error_handler.custom" class="%oneup_uploader.error_handler.noop.class%" public="false" />
            </services>
 

--- a/Uploader/ErrorHandler/DropzoneErrorHandler.php
+++ b/Uploader/ErrorHandler/DropzoneErrorHandler.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Oneup\UploaderBundle\Uploader\ErrorHandler;
+
+use Exception;
+use Oneup\UploaderBundle\Uploader\ErrorHandler\ErrorHandlerInterface;
+use Oneup\UploaderBundle\Uploader\Response\AbstractResponse;
+
+class DropzoneErrorHandler implements ErrorHandlerInterface
+{
+	public function addException(AbstractResponse $response, Exception $exception)
+	{
+		$errors[] = $exception;
+		$message = $exception->getMessage();
+		// Dropzone wants JSON with error message put into 'error' field.
+		// This overwrites the previous error message, so we're only displaying the last one.
+		$response['error'] = $message;
+	}
+}


### PR DESCRIPTION
Added ErrorHandler for Dropzone.

Also added ability to pass HTTP status code to response in createSupportedJsonResponse in AbstractController. This allows to take advantage of HTTP codes for error handling, which is used in Dropzone.

