### PR TITLE
process max size when string

### DIFF
--- a/DependencyInjection/OneupUploaderExtension.php
+++ b/DependencyInjection/OneupUploaderExtension.php
@@ -69,7 +69,7 @@ class OneupUploaderExtension extends Extension
 
     protected function processMapping($key, &$mapping)
     {
-        $mapping['max_size'] = $mapping['max_size'] < 0 ?
+        $mapping['max_size'] = $mapping['max_size'] < 0 || is_string($mapping['max_size']) ?
             $this->getMaxUploadSize($mapping['max_size']) :
             $mapping['max_size']
         ;


### PR DESCRIPTION
Hi,

When setting max_size to 10m, it wont pass in the getMaxUploadSIze method because 10m is cast to int which will be 10 and when comparing with 0, $mapping['max_size'] < 0 is always false.

I think it will fix #148 too.

Regards.