### PR TITLE
Let's see if this gets us symfony 2.6 support.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
     ],
 
     "require": {
-        "symfony/framework-bundle": ">=2.2",
-        "symfony/finder": ">=2.2.0"
+        "symfony/framework-bundle": "~2.2",
+        "symfony/finder": "~2.2.0"
     },
 
     "require-dev": {


### PR DESCRIPTION
It seems that there are some restrictions somewhere.. however I'm unable to figure it out. It might help or not.
A I'm unable to install this bundle in sf2.6 project because of dependency problems...

```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Conclusion: remove symfony/symfony v2.6.1
    - don't install symfony/routing v2.4.10|don't install symfony/symfony v2.6.1
    - don't install symfony/symfony v2.6.1|remove symfony/routing v2.4.10
    - Installation request for symfony/symfony == 2.6.1.0 -> satisfiable by symfony/symfony[v2.6.1].
    - Installation request for symfony/routing == 2.4.10.0 -> satisfiable by symfony/routing[v2.4.10].
```