### PR TITLE
Allow PUT and PATCH method for upload route

### DIFF
--- a/Routing/RouteLoader.php
+++ b/Routing/RouteLoader.php
@@ -36,7 +36,7 @@ class RouteLoader extends Loader
                 array(),
                 '',
                 array(),
-                array('POST')
+                array('POST', 'PUT', 'PATCH')
             );
 
             if ($options['enable_progress'] === true) {

--- a/Routing/RouteLoader.php
+++ b/Routing/RouteLoader.php
@@ -32,14 +32,22 @@ class RouteLoader extends Loader
             $upload = new Route(
                 sprintf('%s/_uploader/%s/upload', $options['route_prefix'], $type),
                 array('_controller' => $service . ':upload', '_format' => 'json'),
-                array('_method' => 'POST')
+                array(),
+                array(),
+                '',
+                array(),
+                array('POST')
             );
 
             if ($options['enable_progress'] === true) {
                 $progress = new Route(
                     sprintf('%s/_uploader/%s/progress', $options['route_prefix'], $type),
                     array('_controller' => $service . ':progress', '_format' => 'json'),
-                    array('_method' => 'POST')
+                    array(),
+                    array(),
+                    '',
+                    array(),
+                    array('POST')
                 );
 
                 $routes->add(sprintf('_uploader_progress_%s', $type), $progress);
@@ -49,7 +57,11 @@ class RouteLoader extends Loader
                 $progress = new Route(
                     sprintf('%s/_uploader/%s/cancel', $options['route_prefix'], $type),
                     array('_controller' => $service . ':cancel', '_format' => 'json'),
-                    array('_method' => 'POST')
+                    array(),
+                    array(),
+                    '',
+                    array(),
+                    array('POST')
                 );
 
                 $routes->add(sprintf('_uploader_cancel_%s', $type), $progress);

--- a/Tests/Controller/AbstractControllerTest.php
+++ b/Tests/Controller/AbstractControllerTest.php
@@ -51,14 +51,16 @@ abstract class AbstractControllerTest extends WebTestCase
         $this->implTestCallBy('DELETE');
     }
 
+    public function testCallByPatch()
+    {
+        $this->implTestCallBy('PATCH');
+    }
+
     public function testCallByPost()
     {
         $this->implTestCallBy('POST');
     }
 
-    /**
-     * @expectedException Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException
-     */
     public function testCallByPut()
     {
         $this->implTestCallBy('PUT');

--- a/Tests/Controller/AbstractControllerTest.php
+++ b/Tests/Controller/AbstractControllerTest.php
@@ -40,8 +40,7 @@ abstract class AbstractControllerTest extends WebTestCase
      */
     public function testCallByGet()
     {
-        $endpoint = $this->helper->endpoint($this->getConfigKey());
-        $this->client->request('GET', $endpoint);
+        $this->implTestCallBy('GET');
     }
 
     /**
@@ -49,8 +48,12 @@ abstract class AbstractControllerTest extends WebTestCase
      */
     public function testCallByDelete()
     {
-        $endpoint = $this->helper->endpoint($this->getConfigKey());
-        $this->client->request('DELETE', $endpoint);
+        $this->implTestCallBy('DELETE');
+    }
+
+    public function testCallByPost()
+    {
+        $this->implTestCallBy('POST');
     }
 
     /**
@@ -58,16 +61,15 @@ abstract class AbstractControllerTest extends WebTestCase
      */
     public function testCallByPut()
     {
-        $endpoint = $this->helper->endpoint($this->getConfigKey());
-        $this->client->request('PUT', $endpoint);
+        $this->implTestCallBy('PUT');
     }
 
-    public function testCallByPost()
+    protected function implTestCallBy($method)
     {
         $client = $this->client;
         $endpoint = $this->helper->endpoint($this->getConfigKey());
 
-        $client->request('POST', $endpoint, array(), array(), $this->requestHeaders);
+        $client->request($method, $endpoint, array(), array(), $this->requestHeaders);
         $response = $client->getResponse();
 
         $this->assertTrue($response->isSuccessful());

--- a/Tests/Routing/RouteLoaderTest.php
+++ b/Tests/Routing/RouteLoaderTest.php
@@ -34,7 +34,7 @@ class RouteLoaderTest extends \PHPUnit_Framework_TestCase
         foreach ($routes as $route) {
             $this->assertInstanceOf('Symfony\Component\Routing\Route', $route);
             $this->assertEquals('json', $route->getDefault('_format'));
-            $this->assertEquals(array('POST'), $route->getMethods());
+            $this->assertContains('POST', $route->getMethods());
         }
     }
 
@@ -56,7 +56,7 @@ class RouteLoaderTest extends \PHPUnit_Framework_TestCase
         foreach ($routes as $route) {
             $this->assertInstanceOf('Symfony\Component\Routing\Route', $route);
             $this->assertEquals('json', $route->getDefault('_format'));
-            $this->assertEquals(array('POST'), $route->getMethods());
+            $this->assertContains('POST', $route->getMethods());
 
             $this->assertEquals(0, strpos($route->getPath(), $prefix));
         }

--- a/Tests/Routing/RouteLoaderTest.php
+++ b/Tests/Routing/RouteLoaderTest.php
@@ -33,8 +33,8 @@ class RouteLoaderTest extends \PHPUnit_Framework_TestCase
 
         foreach ($routes as $route) {
             $this->assertInstanceOf('Symfony\Component\Routing\Route', $route);
-            $this->assertEquals($route->getDefault('_format'), 'json');
-            $this->assertEquals($route->getRequirement('_method'), 'POST');
+            $this->assertEquals('json', $route->getDefault('_format'));
+            $this->assertEquals(array('POST'), $route->getMethods());
         }
     }
 
@@ -55,8 +55,8 @@ class RouteLoaderTest extends \PHPUnit_Framework_TestCase
 
         foreach ($routes as $route) {
             $this->assertInstanceOf('Symfony\Component\Routing\Route', $route);
-            $this->assertEquals($route->getDefault('_format'), 'json');
-            $this->assertEquals($route->getRequirement('_method'), 'POST');
+            $this->assertEquals('json', $route->getDefault('_format'));
+            $this->assertEquals(array('POST'), $route->getMethods());
 
             $this->assertEquals(0, strpos($route->getPath(), $prefix));
         }


### PR DESCRIPTION
The default routing strategy allow only `POST` as HTTP verb to upload files, but `PUT` is actually better for RESTful interfaces. For completeness, I've added also `PATCH`, which may be used when upload of file will alter existing resources.

While I was at it, I've removed deprecated use of `_requirements` for setting `_methods`; this will become a BC in symfony 3.0, so if this branch is not merged you can cherry-pick that commit.

This PR relate to issue #118 , and probably the two are mutually exclusive. Anyway, I cannot understand why and how one would use `GET`...