### PR TITLE
Force clear orphanage

### DIFF
--- a/Uploader/Storage/FilesystemOrphanageStorage.php
+++ b/Uploader/Storage/FilesystemOrphanageStorage.php
@@ -7,6 +7,7 @@ use Oneup\UploaderBundle\Uploader\File\FileInterface;
 use Oneup\UploaderBundle\Uploader\File\FilesystemFile;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpFoundation\File\File;
+use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Finder\Finder;
 
 use Oneup\UploaderBundle\Uploader\Storage\FilesystemStorage;
@@ -54,6 +55,25 @@ class FilesystemOrphanageStorage extends FilesystemStorage implements OrphanageS
             return $return;
         } catch (\Exception $e) {
             return array();
+        }
+    }
+
+    public function clear()
+    {
+        $system = new Filesystem();
+        $finder = new Finder();
+
+        try {
+            $finder->in($this->getFindPath())->date('<=' . -1 * (int) $this->config['maxage'] . 'seconds')->files();
+        } catch (\InvalidArgumentException $e) {
+            // the finder will throw an exception of type InvalidArgumentException
+            // if the directory he should search in does not exist
+            // in that case we don't have anything to clean
+            return;
+        }
+
+        foreach ($finder as $file) {
+            $system->remove($file);
         }
     }
 

--- a/Uploader/Storage/FilesystemOrphanageStorage.php
+++ b/Uploader/Storage/FilesystemOrphanageStorage.php
@@ -58,13 +58,15 @@ class FilesystemOrphanageStorage extends FilesystemStorage implements OrphanageS
         }
     }
 
-    public function clear()
+    public function clear($force = false)
     {
         $system = new Filesystem();
         $finder = new Finder();
 
+        $maxage = $force ? 0 : $this->config['maxage'];
+
         try {
-            $finder->in($this->getFindPath())->date('<=' . -1 * (int) $this->config['maxage'] . 'seconds')->files();
+            $finder->in($this->getFindPath())->date('<=' . -1 * (int) $maxage . 'seconds')->files();
         } catch (\InvalidArgumentException $e) {
             // the finder will throw an exception of type InvalidArgumentException
             // if the directory he should search in does not exist


### PR DESCRIPTION
From the documentation:

> **Known Limitations**
> If a user will upload files through your gallery mapping, and choose not to submit the form, but instead start over with a new form handled by the gallery mapping, the newly uploaded files are going to be moved in the same directory. Therefore you will get both the files uploaded the first time and the second time if you trigger the uploadFiles method.

When the user starts over with a “new” form (i.e. refreshes), I load previously added files into the uploader. There is a button they can use to clear all files, solving the above limitation. I therefore need the option to force clear the current session’s orphanage disregarding the file age.

Another use case would be to force clear the orphanage whenever the form loads, guaranteeing a fresh start.

This was previously discussed in stack overflow posts – which I now can’t find anymore.
