### PR TITLE
replace the deprecated "Twig_Function_Method"

### DIFF
--- a/Twig/Extension/UploaderExtension.php
+++ b/Twig/Extension/UploaderExtension.php
@@ -21,11 +21,11 @@ class UploaderExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            'oneup_uploader_endpoint'   => new \Twig_Function_Method($this, 'endpoint'),
-            'oneup_uploader_progress'   => new \Twig_Function_Method($this, 'progress'),
-            'oneup_uploader_cancel'     => new \Twig_Function_Method($this, 'cancel'),
-            'oneup_uploader_upload_key' => new \Twig_Function_Method($this, 'uploadKey'),
-            'oneup_uploader_maxsize'    => new \Twig_Function_Method($this, 'maxSize'),
+            'oneup_uploader_endpoint'   => new \Twig_SimpleFunction('endpoint', array($this, 'endpoint')),
+            'oneup_uploader_progress'   => new \Twig_SimpleFunction('progress', array($this, 'progress')),
+            'oneup_uploader_cancel'     => new \Twig_SimpleFunction('cancel', array($this, 'cancel')),
+            'oneup_uploader_upload_key' => new \Twig_SimpleFunction('uploadKey', array($this, 'uploadKey')),
+            'oneup_uploader_maxsize'    => new \Twig_SimpleFunction('maxSize', array($this, 'maxSize')),
         );
     }
 

--- a/Twig/Extension/UploaderExtension.php
+++ b/Twig/Extension/UploaderExtension.php
@@ -21,11 +21,11 @@ class UploaderExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            'oneup_uploader_endpoint'   => new \Twig_SimpleFunction('endpoint', array($this, 'endpoint')),
-            'oneup_uploader_progress'   => new \Twig_SimpleFunction('progress', array($this, 'progress')),
-            'oneup_uploader_cancel'     => new \Twig_SimpleFunction('cancel', array($this, 'cancel')),
-            'oneup_uploader_upload_key' => new \Twig_SimpleFunction('uploadKey', array($this, 'uploadKey')),
-            'oneup_uploader_maxsize'    => new \Twig_SimpleFunction('maxSize', array($this, 'maxSize')),
+            new \Twig_SimpleFunction('oneup_uploader_endpoint', array($this, 'endpoint')),
+            new \Twig_SimpleFunction('oneup_uploader_progress', array($this, 'progress')),
+            new \Twig_SimpleFunction('oneup_uploader_cancel', array($this, 'cancel')),
+            new \Twig_SimpleFunction('oneup_uploader_upload_key', array($this, 'uploadKey')),
+            new \Twig_SimpleFunction('oneup_uploader_maxsize', array($this, 'maxSize')),
         );
     }
 


### PR DESCRIPTION
replace it with the recommended "Twig_SimpleFunction" as per Twig docs.
to stop the annoying deprecated log messages.

![image](https://cloud.githubusercontent.com/assets/731905/10714073/9739807e-7ae2-11e5-97a4-97a46f737dca.png)
