### PR TITLE
[RTM] Adding a real unique namer

### DIFF
--- a/Resources/config/uploader.xml
+++ b/Resources/config/uploader.xml
@@ -7,6 +7,7 @@
                <parameter key="oneup_uploader.chunks.manager.class">Oneup\UploaderBundle\Uploader\Chunk\ChunkManager</parameter>
                <parameter key="oneup_uploader.chunks_storage.gaufrette.class">Oneup\UploaderBundle\Uploader\Chunk\Storage\GaufretteStorage</parameter>
                <parameter key="oneup_uploader.chunks_storage.filesystem.class">Oneup\UploaderBundle\Uploader\Chunk\Storage\FilesystemStorage</parameter>
+               <parameter key="oneup_uploader.namer.urlsafename.class">Oneup\UploaderBundle\Uploader\Naming\UrlSafeNamer</parameter>
                <parameter key="oneup_uploader.namer.uniqid.class">Oneup\UploaderBundle\Uploader\Naming\UniqidNamer</parameter>
                <parameter key="oneup_uploader.routing.loader.class">Oneup\UploaderBundle\Routing\RouteLoader</parameter>
                <parameter key="oneup_uploader.storage.gaufrette.class">Oneup\UploaderBundle\Uploader\Storage\GaufretteStorage</parameter>
@@ -38,6 +39,7 @@
 
                <!-- namer -->
                <service id="oneup_uploader.namer.uniqid" class="%oneup_uploader.namer.uniqid.class%" />
+               <service id="oneup_uploader.namer.urlsafe" class="%oneup_uploader.namer.urlsafename.class%" />
 
                <!-- routing -->
                <service id="oneup_uploader.routing.loader" class="%oneup_uploader.routing.loader.class%">

--- a/Resources/doc/custom_namer.md
+++ b/Resources/doc/custom_namer.md
@@ -1,7 +1,24 @@
 Custom Namer
 ============
 
-The purpose of a namer service is to name an uploaded file before it is stored to the storage layer. Currently the OneupUploaderBundle only provides a single namer service called `UniqidNamer`, which will return a system wide unique filename using the `uniqid()` function.
+The purpose of a namer service is to name an uploaded file before it is stored to the storage layer.
+
+Currently the OneupUploaderBundle provides two namer methods.
+- Default used is a namer called `UniqidNamer`, which will return a system wide unique filename using the `uniqid()` function.
+- The other method called `UrlSafeNamer` using `random_bytes` function, see [Using UrlSafeNamer](#urlsafenamer) how to use it
+
+## UrlSafeNamer
+
+To enable UrlSafeNamer you will need to change your namer in your mappings to `oneup_uploader.namer.urlsafe`
+
+Example
+
+```yml
+oneup_uploader:
+    mappings:
+        gallery:
+            namer: oneup_uploader.namer.urlsafe
+```
 
 ## Use a custom namer
 

--- a/Tests/Uploader/Naming/UrlSafeNamerTest.php
+++ b/Tests/Uploader/Naming/UrlSafeNamerTest.php
@@ -1,0 +1,65 @@
+<?php
+namespace Oneup\UploaderBundle\Tests\Uploader\Naming;
+
+use Oneup\UploaderBundle\Tests\Uploader\File\FileTest;
+use Oneup\UploaderBundle\Uploader\File\FilesystemFile;
+use Oneup\UploaderBundle\Uploader\Naming\UrlSafeNamer;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+
+class UrlSafeNamerTest extends FileTest
+{
+
+    public function setUp()
+    {
+        $this->path = sys_get_temp_dir(). '/oneup_namer_test';
+        mkdir($this->path);
+
+        $this->basename = 'test_file.txt';
+        $this->pathname = $this->path .'/'. $this->basename;
+        $this->extension = 'txt';
+        $this->size = 9; //something = 9 bytes
+        $this->mimeType = 'text/plain';
+
+        file_put_contents($this->pathname, 'something');
+
+        $this->file = new FilesystemFile(new UploadedFile($this->pathname, 'test_file.txt', null, null, null, true));
+    }
+
+    public function testCanGetString()
+    {
+        $namer = new UrlSafeNamer();
+        $this->assertTrue(is_string($namer->name($this->file)));
+        $this->assertStringEndsWith($this->extension, $namer->name($this->file));
+    }
+
+    public function test_two_file_names_not_equal()
+    {
+        $file = $this->getMockBuilder('Oneup\UploaderBundle\Uploader\File\FilesystemFile')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $file
+            ->expects($this->any())
+            ->method('getExtension')
+            ->will($this->returnValue('jpeg'))
+        ;
+
+        /** @var \Oneup\UploaderBundle\Uploader\File\FileInterface $file */
+        $namer = new UrlSafeNamer();
+        // Trying 200 times just to be sure
+        for($i = 0; $i < 200; $i++) {
+            $name1 = $namer->name($file);
+            $name2 = $namer->name($file);
+            $this->assertNotEquals($name1, $name2);
+        }
+
+    }
+
+    public function tearDown()
+    {
+        unlink($this->pathname);
+        rmdir($this->path);
+    }
+
+}

--- a/Tests/Uploader/Naming/UrlSafeNamerTest.php
+++ b/Tests/Uploader/Naming/UrlSafeNamerTest.php
@@ -34,23 +34,11 @@ class UrlSafeNamerTest extends FileTest
 
     public function test_two_file_names_not_equal()
     {
-        $file = $this->getMockBuilder('Oneup\UploaderBundle\Uploader\File\FilesystemFile')
-            ->disableOriginalConstructor()
-            ->getMock()
-        ;
-
-        $file
-            ->expects($this->any())
-            ->method('getExtension')
-            ->will($this->returnValue('jpeg'))
-        ;
-
-        /** @var \Oneup\UploaderBundle\Uploader\File\FileInterface $file */
         $namer = new UrlSafeNamer();
         // Trying 200 times just to be sure
         for($i = 0; $i < 200; $i++) {
-            $name1 = $namer->name($file);
-            $name2 = $namer->name($file);
+            $name1 = $namer->name($this->file);
+            $name2 = $namer->name($this->file);
             $this->assertNotEquals($name1, $name2);
         }
 

--- a/Uploader/Naming/UrlSafeNamer.php
+++ b/Uploader/Naming/UrlSafeNamer.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Oneup\UploaderBundle\Uploader\Naming;
+
+use Oneup\UploaderBundle\Uploader\File\FileInterface;
+
+class UrlSafeNamer implements NamerInterface
+{
+
+    /**
+     * Name a given file and return the name
+     *
+     * @param  FileInterface $file
+     * @return string
+     */
+    public function name(FileInterface $file)
+    {
+        $bytes = random_bytes(256 / 8);
+        return rtrim(strtr(base64_encode($bytes), '+/', '-_'), '=') . '.' . $file->getExtension();
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
 
     "require": {
         "symfony/framework-bundle": "^2.4.0|~3.0",
-        "symfony/finder": "^2.4.0|~3.0"
+        "symfony/finder": "^2.4.0|~3.0",
+        "paragonie/random_compat": "^1.1"
     },
 
     "require-dev": {


### PR DESCRIPTION
Added a real unique file namer, though its not used default, it will give longer filenames.

I have called it "UrlSafeNamer" as the namer is using the same namer as Symfony uses to JWT tokens, which also is url safe.

Its using random_bytes which is only available in PHP 7.0 so [paragonie/random_compat](https://github.com/paragonie/random_compat) is used to provide random_bytes for older PHP versions. (all the way down to PHP 5.2)

Also added documentation on how to use it.

Fixes #199 
