### PR TITLE
Fix: README.md Symfony 2.8.2 / OneupUploaderBundle 1.5.0

### DIFF
--- a/Resources/doc/custom_logic.md
+++ b/Resources/doc/custom_logic.md
@@ -50,7 +50,7 @@ And register it in your `services.xml`.
 services:
     acme_hello.upload_listener:
         class: AppBundle\EventListener\UploadListener
-        argument: ["@doctrine.orm.entity_manager"]
+        arguments: ["@doctrine.orm.entity_manager"]
         tags:
             - { name: kernel.event_listener, event: oneup_uploader.post_persist, method: onUpload }
 ```


### PR DESCRIPTION
Error without the fix :
UploadListener::__construct() must be an instance of
Doctrine\Common\Persistence\ObjectManager, none given