### PR TITLE
Custom subfolder / Custom data in the namer

### DIFF
--- a/Controller/AbstractController.php
+++ b/Controller/AbstractController.php
@@ -119,7 +119,7 @@ abstract class AbstractController
 
         // no error happend, proceed
         $namer = $this->container->get($this->config['namer']);
-        $name  = $namer->name($file);
+        $name  = $namer->name($file, $request);
 
         // perform the real upload
         $uploaded = $this->storage->upload($file, $name);

--- a/Resources/doc/custom_namer.md
+++ b/Resources/doc/custom_namer.md
@@ -62,8 +62,6 @@ To send custom data, follow instructions as described in the [Custom Logic Docum
 You can access to your custom data in the same way :
 
 ```php
-<?php
-
 class CustomNamer implements NamerInterface
 {
     public function name(FileInterface $file, Request $request)

--- a/Resources/doc/custom_namer.md
+++ b/Resources/doc/custom_namer.md
@@ -12,12 +12,14 @@ First, create a custom namer which implements ```Oneup\UploaderBundle\Uploader\N
 
 namespace AppBundle\Uploader\Naming;
 
+use Symfony\Component\HttpFoundation\Request;
+
 use Oneup\UploaderBundle\Uploader\File\FileInterface;
 use Oneup\UploaderBundle\Uploader\Naming\NamerInterface;
 
 class CatNamer implements NamerInterface
 {
-    public function name(FileInterface $file)
+    public function name(FileInterface $file, Request $request)
     {
         return 'grumpycat.jpg';
     }
@@ -50,3 +52,23 @@ oneup_uploader:
 ```
 
 Every file uploaded through the `Controller` of this mapping will be named with your custom namer.
+
+## Add custom data in your file name
+
+As you can see, the namer can access to the Request Object, so you can easily send any custom data and use it to name your files.
+
+To send custom data, follow instructions as described in the [Custom Logic Documentation](custom_logic.md).
+
+You can access to your custom data in the same way :
+
+```php
+<?php
+
+class CustomNamer implements NamerInterface
+{
+    public function name(FileInterface $file, Request $request)
+    {
+        return $request->get('my_custom_data') . $file->getExtension();
+    }
+}
+```

--- a/Resources/doc/custom_subfolder.md
+++ b/Resources/doc/custom_subfolder.md
@@ -1,0 +1,15 @@
+Set a custom subfolder
+======================
+
+If you want to add a custom subfolder to the path of uploaded file (e.g. dynamic subfolder), the only thing you need to do is to send a custom data named `subfolder`, containing a string with the desired subfolder.
+
+## Example
+The following example is an implementation with BluImp JQuery File Upload.
+
+```js
+$('#fileupload').fileupload({
+    formData: {subfolder: 'my_custom_folder'}
+});
+```
+
+With this example, files will be uploaded in the folder `my_custom_folder` within the main uploads folder (e.g. `web/uploads`).

--- a/Uploader/Naming/NamerInterface.php
+++ b/Uploader/Naming/NamerInterface.php
@@ -2,6 +2,8 @@
 
 namespace Oneup\UploaderBundle\Uploader\Naming;
 
+use Symfony\Component\HttpFoundation\Request;
+
 use Oneup\UploaderBundle\Uploader\File\FileInterface;
 
 interface NamerInterface
@@ -12,5 +14,5 @@ interface NamerInterface
      * @param  FileInterface $file
      * @return string
      */
-    public function name(FileInterface $file, $request);
+    public function name(FileInterface $file, Request $request);
 }

--- a/Uploader/Naming/NamerInterface.php
+++ b/Uploader/Naming/NamerInterface.php
@@ -12,6 +12,8 @@ interface NamerInterface
      * Name a given file and return the name
      *
      * @param  FileInterface $file
+     * @param Request $request The request object.
+     * 
      * @return string
      */
     public function name(FileInterface $file, Request $request);

--- a/Uploader/Naming/NamerInterface.php
+++ b/Uploader/Naming/NamerInterface.php
@@ -12,5 +12,5 @@ interface NamerInterface
      * @param  FileInterface $file
      * @return string
      */
-    public function name(FileInterface $file);
+    public function name(FileInterface $file, $request);
 }

--- a/Uploader/Naming/UniqidNamer.php
+++ b/Uploader/Naming/UniqidNamer.php
@@ -2,11 +2,13 @@
 
 namespace Oneup\UploaderBundle\Uploader\Naming;
 
+use Symfony\Component\HttpFoundation\Request;
+
 use Oneup\UploaderBundle\Uploader\File\FileInterface;
 
 class UniqidNamer implements NamerInterface
 {
-    public function name(FileInterface $file, $request)
+    public function name(FileInterface $file, Request $request)
     {
         $subfolder = '';
         if ($subfolder = $request->get('subfolder')) $subfolder .= '/';

--- a/Uploader/Naming/UniqidNamer.php
+++ b/Uploader/Naming/UniqidNamer.php
@@ -6,7 +6,7 @@ use Oneup\UploaderBundle\Uploader\File\FileInterface;
 
 class UniqidNamer implements NamerInterface
 {
-    public function name(FileInterface $file)
+    public function name(FileInterface $file, $request)
     {
         return sprintf('%s.%s', uniqid(), $file->getExtension());
     }

--- a/Uploader/Naming/UniqidNamer.php
+++ b/Uploader/Naming/UniqidNamer.php
@@ -8,6 +8,14 @@ use Oneup\UploaderBundle\Uploader\File\FileInterface;
 
 class UniqidNamer implements NamerInterface
 {
+    /**
+     * Name a given file and return the name
+     *
+     * @param  FileInterface $file
+     * @param Request $request The request object.
+     * 
+     * @return string
+     */
     public function name(FileInterface $file, Request $request)
     {
         $subfolder = '';

--- a/Uploader/Naming/UniqidNamer.php
+++ b/Uploader/Naming/UniqidNamer.php
@@ -8,6 +8,8 @@ class UniqidNamer implements NamerInterface
 {
     public function name(FileInterface $file, $request)
     {
-        return sprintf('%s.%s', uniqid(), $file->getExtension());
+        $subfolder = '';
+        if ($subfolder = $request->get('subfolder')) $subfolder .= '/';
+        return sprintf('%s.%s', $subfolder.uniqid(), $file->getExtension());
     }
 }


### PR DESCRIPTION
Hello !
Here is a simple way to allow a user to set a custom subfolder.
It works with the Request object, sent to the NamerInterface.
With this little improvement we're able to send any custom data to the Namer.
By default, the OneUp UniqIdNamer will check for a "subfolder" named data. If it's found, subfolder is added to the name.

This improvement let also the user to send any data, like a dynamic string to use in his own custom namer. 3 lines of code for a feature I think everyone wants :)

PS : Docs updated in the commits, but Im french and my english is not perfect :p
