### PR TITLE
Enables and fixes some skipped Flysystem tests

### DIFF
--- a/Tests/Uploader/Storage/FlysystemOrphanageStorageTest.php
+++ b/Tests/Uploader/Storage/FlysystemOrphanageStorageTest.php
@@ -29,14 +29,14 @@ class FlysystemOrphanageStorageTest extends OrphanageTest
         $this->tempDirectory = $this->realDirectory . '/' . $this->orphanageKey;
         $this->payloads = array();
 
-        if (!$this->checkIfTempnameMatchesAfterCreation()) {
-            $this->markTestSkipped('Temporary directories do not match');
-        }
-
         $filesystem = new Filesystem();
         $filesystem->mkdir($this->realDirectory);
         $filesystem->mkdir($this->chunkDirectory);
         $filesystem->mkdir($this->tempDirectory);
+
+        if (!$this->checkIfTempnameMatchesAfterCreation()) {
+            $this->markTestSkipped('Temporary directories do not match');
+        }
 
         $adapter = new Adapter($this->realDirectory, true);
         $filesystem = new FSAdapter($adapter);
@@ -61,7 +61,7 @@ class FlysystemOrphanageStorageTest extends OrphanageTest
             fwrite($pointer, str_repeat('A', 1024), 1024);
             fclose($pointer);
 
-            //gaufrette needs the key relative to it's root
+            //file key needs to be relative to the root of the flysystem filesystem
             $fileKey = str_replace($this->realDirectory, '', $file);
 
             $this->payloads[] = new FlysystemFile(new File($filesystem, $fileKey), $filesystem);
@@ -95,7 +95,9 @@ class FlysystemOrphanageStorageTest extends OrphanageTest
         $this->assertCount($this->numberOfPayloads, $finder);
 
         $finder = new Finder();
-        $finder->in($this->realDirectory)->exclude(array($this->orphanageKey, $this->chunksKey))->files();
+        $finder->in($this->realDirectory)
+            ->exclude(array($this->orphanageKey, $this->chunksKey))
+            ->files();
         $this->assertCount(0, $finder);
 
         $files = $this->orphanage->uploadFiles();
@@ -114,6 +116,10 @@ class FlysystemOrphanageStorageTest extends OrphanageTest
 
     public function checkIfTempnameMatchesAfterCreation()
     {
-        return strpos(tempnam($this->chunkDirectory, 'uploader'), $this->chunkDirectory) === 0;
+        $testName = tempnam($this->chunkDirectory, 'uploader');
+        $result = strpos($testName, $this->chunkDirectory) === 0;
+        unlink($testName);
+
+        return $result;
     }
 }

--- a/Uploader/Storage/FlysystemOrphanageStorage.php
+++ b/Uploader/Storage/FlysystemOrphanageStorage.php
@@ -71,13 +71,19 @@ class FlysystemOrphanageStorage extends FlysystemStorage implements OrphanageSto
 
     public function getFiles()
     {
-        $keys = $this->chunkStorage->getFilesystem()->listFiles($this->getPath());
-        $keys = $keys['keys'];
+        $fileList = $this->chunkStorage
+            ->getFilesystem()
+            ->listContents($this->getPath());
         $files = array();
 
-        foreach ($keys as $key) {
-            // gotta pass the filesystem to both as you can't get it out from one..
-            $files[$key] = new FlysystemFile(new File($this->chunkStorage->getFilesystem(), $key), $this->chunkStorage->getFilesystem());
+        foreach ($fileList as $fileDetail) {
+            $key = $fileDetail['path'];
+            if ($fileDetail['type'] == 'file') {
+                $files[$key] = new FlysystemFile(
+                    new File($this->chunkStorage->getFilesystem(), $key),
+                    $this->chunkStorage->getFilesystem()
+                );
+            }
         }
 
         return $files;


### PR DESCRIPTION
While troubleshooting some issues I was having using the uploader bundle (with flysystem storage) I noticed that all the PHPUnit tests for the FlysystemOrphanStorage class were being flagged as skipped.  This PR adapts the test class to run those tests and tweaks the implementation class to make them pass.
