### PR TITLE
Remove metric suffix from input before multiplication

### DIFF
--- a/DependencyInjection/OneupUploaderExtension.php
+++ b/DependencyInjection/OneupUploaderExtension.php
@@ -294,11 +294,14 @@ class OneupUploaderExtension extends Extension
         // see: http://www.php.net/manual/en/function.ini-get.php
         $input = trim($input);
         $last  = strtolower($input[strlen($input) - 1]);
+        $numericInput = substr($input, 0, -1);
 
         switch ($last) {
-            case 'g': $input *= 1024;
-            case 'm': $input *= 1024;
-            case 'k': $input *= 1024;
+            case 'g': $numericInput *= 1024;
+            case 'm': $numericInput *= 1024;
+            case 'k': $numericInput *= 1024;
+
+            return $numericInput;
         }
 
         return $input;


### PR DESCRIPTION
Eliminates notice on php 7.1 caused by invalid string in arithmetic

Due to this RFC pass - https://wiki.php.net/rfc/invalid_strings_in_arithmetic code like below produces notice on php 7.1:

```
$a = "5k" * "5";
```

This commit removes metric suffix (`k` or `m` or `g`) from multiplied numbers in `getValueInBytes` method of bundle's Symfony extension.