### PR TITLE
[RTM] Include mime type with file upload

### DIFF
--- a/Uploader/Storage/FlysystemStorage.php
+++ b/Uploader/Storage/FlysystemStorage.php
@@ -45,7 +45,9 @@ class FlysystemStorage implements StorageInterface
         }
 
         $stream = fopen($file->getPathname(), 'r+');
-        $this->filesystem->putStream($name, $stream);
+        $this->filesystem->putStream($name, $stream, array(
+            'mimetype' => $file->getMimeType()
+        ));
         if (is_resource($stream)) {
             fclose($stream);
         }


### PR DESCRIPTION
When reading the file mime type through php, the information is still in place.  However, when using AWS S3, the uploaded object's metadata always defaults to "application/octet-stream" inside of AWS.  Including the "mimetype" option with the "putstream" function seems to correct this problem; setting the AWS object to the correct content type.