### PR TITLE
Fix for blueimp uploading not translating error messages

### DIFF
--- a/Resources/config/errorhandler.xml
+++ b/Resources/config/errorhandler.xml
@@ -12,7 +12,9 @@
            <services>
                <service id="oneup_uploader.error_handler.noop" class="%oneup_uploader.error_handler.noop.class%" public="false" />
                <service id="oneup_uploader.error_handler.fineuploader" class="%oneup_uploader.error_handler.noop.class%" public="false" />
-               <service id="oneup_uploader.error_handler.blueimp" class="%oneup_uploader.error_handler.blueimp.class%" public="false" />
+               <service id="oneup_uploader.error_handler.blueimp" class="%oneup_uploader.error_handler.blueimp.class%" public="false">
+                   <argument type="service" id="translator"/>
+               </service>
                <service id="oneup_uploader.error_handler.uploadify" class="%oneup_uploader.error_handler.noop.class%" public="false" />
                <service id="oneup_uploader.error_handler.yui3" class="%oneup_uploader.error_handler.noop.class%" public="false" />
                <service id="oneup_uploader.error_handler.fancyupload" class="%oneup_uploader.error_handler.noop.class%" public="false" />

--- a/Tests/Controller/BlueimpValidationTest.php
+++ b/Tests/Controller/BlueimpValidationTest.php
@@ -2,6 +2,7 @@
 
 namespace Oneup\UploaderBundle\Tests\Controller;
 
+use Symfony\Bundle\FrameworkBundle\Client;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 use Oneup\UploaderBundle\Tests\Controller\AbstractValidationTest;
 use Oneup\UploaderBundle\UploadEvents;
@@ -11,6 +12,7 @@ class BlueimpValidationTest extends AbstractValidationTest
     public function testAgainstMaxSize()
     {
         // assemble a request
+        /** @var Client $client */
         $client = $this->client;
         $endpoint = $this->helper->endpoint($this->getConfigKey());
 
@@ -20,6 +22,7 @@ class BlueimpValidationTest extends AbstractValidationTest
         //$this->assertTrue($response->isNotSuccessful());
         $this->assertEquals($response->headers->get('Content-Type'), 'application/json');
         $this->assertCount(0, $this->getUploadedFiles());
+        $this->assertFalse(strpos($response->getContent(), 'error.maxsize'), "Failed to translate error id into lang");
     }
 
     public function testEvents()

--- a/Uploader/ErrorHandler/BlueimpErrorHandler.php
+++ b/Uploader/ErrorHandler/BlueimpErrorHandler.php
@@ -5,12 +5,23 @@ namespace Oneup\UploaderBundle\Uploader\ErrorHandler;
 use Exception;
 use Oneup\UploaderBundle\Uploader\ErrorHandler\ErrorHandlerInterface;
 use Oneup\UploaderBundle\Uploader\Response\AbstractResponse;
+use Symfony\Component\Translation\TranslatorInterface;
 
 class BlueimpErrorHandler implements ErrorHandlerInterface
 {
+    /**
+     * @var TranslatorInterface
+     */
+    private $translator;
+
+    public function __construct(TranslatorInterface $translator)
+    {
+        $this->translator = $translator;
+    }
+
     public function addException(AbstractResponse $response, Exception $exception)
     {
-        $message = $exception->getMessage();
+        $message = $this->translator->trans($exception->getMessage(), array(), 'OneupUploaderBundle');
         $response->addToOffset(array('error' => $message), array('files'));
     }
 }


### PR DESCRIPTION
Hi There,

I ran into the blueimp uploader not doing the i18n issue that some others have. 

I found the previous attempt at fixing this in the list of pending pull requests, but it has languished since 2014, so I thought I would have a crack at getting it fixed.

I have added an addition assert to the blueimp max file size test to ensure that translation is being done properly.

On my machine at least I needed to add some addition packages for the unit tests to run successfully, the change here looked like
```
diff --git a/composer.json b/composer.json
index b0ef8ce..22be261 100644
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,11 @@
     "require": {
         "php":">=5.4",
         "symfony/framework-bundle": "^2.4.0|~3.0",
-        "symfony/finder": "^2.4.0|~3.0"
+        "symfony/finder": "^2.4.0|~3.0",
+        "symfony/http-kernel": "3.2.*",
+        "symfony/asset": "^3.2",
+        "symfony/templating": "^3.2",
+        "symfony/translation": "^3.2"
     },
 
     "require-dev": {
```