### PR TITLE
Custom endpoint routes

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -75,6 +75,27 @@ class Configuration implements ConfigurationInterface
                                 ->end()
                             ->end()
                             ->scalarNode('route_prefix')->defaultValue('')->end()
+                            ->arrayNode('endpoints')
+                                ->beforeNormalization()
+                                    ->ifString()
+                                    ->then(function ($v) {
+                                        if (substr($v, -1) != '/') {
+                                            $v .= '/';
+                                        }
+                                        return [
+                                            'upload' => $v.'upload',
+                                            'progress' => $v.'progress',
+                                            'cancel' => $v.'cancel',
+                                        ];
+                                    })
+                                ->end()
+                                ->addDefaultsIfNotSet()
+                                ->children()
+                                    ->scalarNode('upload')->defaultNull()->end()
+                                    ->scalarNode('progress')->defaultNull()->end()
+                                    ->scalarNode('cancel')->defaultNull()->end()
+                                ->end()
+                            ->end()
                             ->arrayNode('allowed_mimetypes')
                                 ->prototype('scalar')->end()
                             ->end()

--- a/DependencyInjection/OneupUploaderExtension.php
+++ b/DependencyInjection/OneupUploaderExtension.php
@@ -84,7 +84,8 @@ class OneupUploaderExtension extends Extension
         return array($controllerName, array(
             'enable_progress' => $mapping['enable_progress'],
             'enable_cancelation' => $mapping['enable_cancelation'],
-            'route_prefix' => $mapping['route_prefix']
+            'route_prefix' => $mapping['route_prefix'],
+            'endpoints' => $mapping['endpoints'],
         ));
     }
 

--- a/Resources/doc/configuration_reference.md
+++ b/Resources/doc/configuration_reference.md
@@ -35,6 +35,10 @@ oneup_uploader:
                 stream_wrapper:       ~
                 sync_buffer_size:     100K
             route_prefix:
+            endpoints:
+                upload: ~
+                progress: ~
+                cancel: ~
             allowed_mimetypes:     []
             disallowed_mimetypes:  []
             error_handler:        oneup_uploader.error_handler.noop

--- a/Routing/RouteLoader.php
+++ b/Routing/RouteLoader.php
@@ -30,7 +30,7 @@ class RouteLoader extends Loader
             $options = $controllerArray[1];
 
             $upload = new Route(
-                sprintf('%s/_uploader/%s/upload', $options['route_prefix'], $type),
+                $options['endpoints']['upload'] ?: sprintf('%s/_uploader/%s/upload', $options['route_prefix'], $type),
                 array('_controller' => $service . ':upload', '_format' => 'json'),
                 array(),
                 array(),
@@ -41,7 +41,7 @@ class RouteLoader extends Loader
 
             if ($options['enable_progress'] === true) {
                 $progress = new Route(
-                    sprintf('%s/_uploader/%s/progress', $options['route_prefix'], $type),
+                    $options['endpoints']['progress'] ?: sprintf('%s/_uploader/%s/progress', $options['route_prefix'], $type),
                     array('_controller' => $service . ':progress', '_format' => 'json'),
                     array(),
                     array(),
@@ -55,7 +55,7 @@ class RouteLoader extends Loader
 
             if ($options['enable_cancelation'] === true) {
                 $progress = new Route(
-                    sprintf('%s/_uploader/%s/cancel', $options['route_prefix'], $type),
+                    $options['endpoints']['cancel'] ?: sprintf('%s/_uploader/%s/cancel', $options['route_prefix'], $type),
                     array('_controller' => $service . ':cancel', '_format' => 'json'),
                     array(),
                     array(),

--- a/Tests/Routing/RouteLoaderTest.php
+++ b/Tests/Routing/RouteLoaderTest.php
@@ -15,12 +15,22 @@ class RouteLoaderTest extends \PHPUnit_Framework_TestCase
             'cat' => array($cat, array(
                 'enable_progress' => false,
                 'enable_cancelation' => false,
-                'route_prefix' => ''
+                'route_prefix' => '',
+                'endpoints' => array(
+                    'upload' => null,
+                    'progress' => null,
+                    'cancel' => null,
+                ),
             )),
             'dog' => array($dog, array(
                 'enable_progress' => true,
                 'enable_cancelation' => true,
-                'route_prefix' => ''
+                'route_prefix' => '',
+                'endpoints' => array(
+                    'upload' => null,
+                    'progress' => null,
+                    'cancel' => null,
+                ),
             )),
         ));
 
@@ -47,7 +57,12 @@ class RouteLoaderTest extends \PHPUnit_Framework_TestCase
             'cat' => array($cat, array(
                 'enable_progress' => false,
                 'enable_cancelation' => false,
-                'route_prefix' => $prefix
+                'route_prefix' => $prefix,
+                'endpoints' => array(
+                    'upload' => null,
+                    'progress' => null,
+                    'cancel' => null,
+                ),
             ))
         ));
 
@@ -59,6 +74,35 @@ class RouteLoaderTest extends \PHPUnit_Framework_TestCase
             $this->assertContains('POST', $route->getMethods());
 
             $this->assertEquals(0, strpos($route->getPath(), $prefix));
+        }
+    }
+
+    public function testCustomEndpointRoutes()
+    {
+        $customEndpointUpload = '/grumpy/cats/upload';
+        $cat = 'GrumpyCatController';
+
+        $routeLoader = new RouteLoader(array(
+            'cat' => array($cat, array(
+                'enable_progress' => false,
+                'enable_cancelation' => false,
+                'route_prefix' => '',
+                'endpoints' => array(
+                    'upload' => $customEndpointUpload,
+                    'progress' => null,
+                    'cancel' => null,
+                ),
+            ))
+        ));
+
+        $routes = $routeLoader->load(null);
+
+        foreach ($routes as $route) {
+            $this->assertInstanceOf('Symfony\Component\Routing\Route', $route);
+            $this->assertEquals('json', $route->getDefault('_format'));
+            $this->assertContains('POST', $route->getMethods());
+
+            $this->assertEquals($customEndpointUpload, $route->getPath());
         }
     }
 }


### PR DESCRIPTION
When defining a mapping like:
```yaml
# app/config/config.yml

oneup_uploader:
    mappings:
        documents:
            frontend: fineuploader
```
You get the following route: `_uploader/documents/upload`

This is not very nice when building an api. Instead one would like having a route like:
`/api/documents/upload`

I've added endpoint configuration to overrule the default behavior and define your own routes:
```yaml
# app/config/config.yml

oneup_uploader:
    mappings:
        documents:
            frontend: fineuploader
            endpoints:
                upload: 'api/documents/upload'
                progress: 'api/documents/progress'
                cancel: 'api/documents/cancel'
```
It's also possible to use a shorter notation: `endpoints: 'api/documents'`