### PR TITLE
Fix for FlysystemStorage ignoring path on upload

### DIFF
--- a/Tests/Uploader/Storage/FlysystemStorageTest.php
+++ b/Tests/Uploader/Storage/FlysystemStorageTest.php
@@ -53,6 +53,22 @@ class FlysystemStorageTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function testUploadWithPath()
+    {
+        $payload = new FilesystemFile(new UploadedFile($this->file, 'grumpycat.jpeg', null, null, null, true));
+        $this->storage->upload($payload, 'notsogrumpyanymore.jpeg', 'cat');
+
+        $finder = new Finder();
+        $finder->in($this->directory)->files();
+
+        $this->assertCount(1, $finder);
+
+        foreach ($finder as $file) {
+            $this->assertEquals($file->getFilename(), 'notsogrumpyanymore.jpeg');
+            $this->assertEquals($file->getSize(), 1024);
+        }
+    }
+
     public function tearDown()
     {
         $filesystem = new Filesystem();

--- a/Uploader/Storage/FlysystemStorage.php
+++ b/Uploader/Storage/FlysystemStorage.php
@@ -45,7 +45,7 @@ class FlysystemStorage implements StorageInterface
         }
 
         $stream = fopen($file->getPathname(), 'r+');
-        $this->filesystem->putStream($name, $stream, array(
+        $this->filesystem->putStream($path, $stream, array(
             'mimetype' => $file->getMimeType()
         ));
         if (is_resource($stream)) {


### PR DESCRIPTION
It appears that the third parameter (path) to the upload() method of the FlysystemStorage class is basically ignored.  I've added a unit test that demonstrates the failure and updated the storage class to fix the issue.