### PR TITLE
version 1.4 seems outdated

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -34,7 +34,7 @@ Perform the following steps to install and use the basic functionality of the On
 
 Add OneupUploaderBundle to your composer.json using the following construct:
 
-    $ composer require oneup/uploader-bundle "~1.4"
+    $ composer require oneup/uploader-bundle
 
 Composer will install the bundle to your project's ``vendor/oneup/uploader-bundle`` directory.
 


### PR DESCRIPTION
I think is better to skip the version part in installation with composer, nowadays composer seems smart enough to catch the right stable version; so you don't need to keep track of this small but important changes to docs