### PR TITLE
[Documentation] Change test dropzone js path

### DIFF
--- a/Resources/doc/frontend_dropzone.md
+++ b/Resources/doc/frontend_dropzone.md
@@ -4,7 +4,7 @@ Use Dropzone in your Symfony2 application
 Download [Dropzone](http://www.dropzonejs.com/) and include it in your template. Connect the `action` property of the form to the dynamic route `_uploader_{mapping_name}`.
 
 ```html
-<script type="text/javascript" src="https://raw.github.com/enyo/dropzone/master/dist/dropzone.js"></script>
+<script type="text/javascript" src="https://rawgit.com/enyo/dropzone/master/dist/dropzone.js"></script>
 
 <form action="{{ oneup_uploader_endpoint('gallery') }}" class="dropzone" style="width:200px; height:200px; border:4px dashed black">
 </form>


### PR DESCRIPTION
I have tested integration with dropzone as you suggest, but unfortunately, I have encounter following error:
![zrzut ekranu 2018-01-29 o 13 55 39](https://user-images.githubusercontent.com/6213903/35511459-4cfc9432-04fc-11e8-8e6e-a929a2ed2f8a.png)

Following [Dropzone installation guide](http://www.dropzonejs.com/#installation) I have found [this source code](https://gitlab.com/meno/dropzone/raw/master/website/examples/simple.html) which contains the path I have proposed in this PR. 

Anyway, thank you very much for this great bundle! ;)