### PR TITLE
[Documentation] Change console execution path

### DIFF
--- a/Resources/doc/chunked_uploads.md
+++ b/Resources/doc/chunked_uploads.md
@@ -82,6 +82,6 @@ See the [Use Chunked Uploads behind Load Balancers](load_balancers.md) section i
 
 The ChunkManager can be forced to clean up old and orphanaged chunks by using the command provided by the OneupUploaderBundle.
 
-    $> php app/console oneup:uploader:clear-chunks
+    $> php bin/console oneup:uploader:clear-chunks
 
 This parameter will clean all chunk files older than the `maxage` value in your configuration.


### PR DESCRIPTION
From Symfony 3.* folder structure has changed, and console component is placed in `bin` folder. 