### PR TITLE
Updated FineUploader official manuel link

### DIFF
--- a/Resources/doc/frontend_fineuploader.md
+++ b/Resources/doc/frontend_fineuploader.md
@@ -33,7 +33,7 @@ oneup_uploader:
             frontend: fineuploader
 ```
 
-Be sure to check out the [official manual](https://github.com/Widen/fine-uploader/blob/master/readme.md) for details on the configuration.
+Be sure to check out the [official manual](https://github.com/FineUploader/fine-uploader/blob/master/README.md) for details on the configuration.
 
 Next steps
 ----------


### PR DESCRIPTION
Changed route to the [official FineUploader github](https://github.com/FineUploader/fine-uploader/) README.md file.