### PR TITLE
Register commands to avoid deprecations in Symfony >= 3.4

### DIFF
--- a/Command/ClearChunkCommand.php
+++ b/Command/ClearChunkCommand.php
@@ -8,10 +8,12 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class ClearChunkCommand extends ContainerAwareCommand
 {
+    protected static $defaultName = 'oneup:uploader:clear-chunks'; // Make command lazy load
+
     protected function configure()
     {
         $this
-            ->setName('oneup:uploader:clear-chunks')
+            ->setName(self::$defaultName) // BC with 2.7
             ->setDescription('Clear chunks according to the max-age you defined in your configuration.')
         ;
     }

--- a/Command/ClearOrphansCommand.php
+++ b/Command/ClearOrphansCommand.php
@@ -8,10 +8,12 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class ClearOrphansCommand extends ContainerAwareCommand
 {
+    protected static $defaultName = 'oneup:uploader:clear-orphans'; // Make command lazy load
+
     protected function configure()
     {
         $this
-            ->setName('oneup:uploader:clear-orphans')
+            ->setName(self::$defaultName) // BC with 2.7
             ->setDescription('Clear orphaned uploads according to the max-age you defined in your configuration.')
         ;
     }

--- a/Resources/config/uploader.xml
+++ b/Resources/config/uploader.xml
@@ -24,6 +24,8 @@
                <parameter key="oneup_uploader.controller.mooupload.class">Oneup\UploaderBundle\Controller\MooUploadController</parameter>
                <parameter key="oneup_uploader.controller.plupload.class">Oneup\UploaderBundle\Controller\PluploadController</parameter>
                <parameter key="oneup_uploader.controller.dropzone.class">Oneup\UploaderBundle\Controller\DropzoneController</parameter>
+               <parameter key="oneup_uploader.command.clear_chunks.class">Oneup\UploaderBundle\Command\ClearChunkCommand</parameter>
+               <parameter key="oneup_uploader.command.clear_orphans.class">Oneup\UploaderBundle\Command\ClearOrphansCommand</parameter>
            </parameters>
 
            <services>
@@ -40,13 +42,21 @@
                </service>
 
                <!-- namer -->
-               <service id="oneup_uploader.namer.uniqid" class="%oneup_uploader.namer.uniqid.class%" public="true"/>
+               <service id="oneup_uploader.namer.uniqid" class="%oneup_uploader.namer.uniqid.class%" public="true" />
                <service id="oneup_uploader.namer.urlsafe" class="%oneup_uploader.namer.urlsafename.class%" />
 
                <!-- routing -->
                <service id="oneup_uploader.routing.loader" class="%oneup_uploader.routing.loader.class%" public="true">
                    <argument>%oneup_uploader.controllers%</argument>
                    <tag name="routing.loader" />
+               </service>
+
+               <!-- commands -->
+               <service id="oneup_uploader.command.clear_chunks" class="%oneup_uploader.command.clear_chunks.class%">
+                   <tag name="console.command" command="oneup:uploader:clear-chunks" />
+               </service>
+               <service id="oneup_uploader.command.clear_orphans" class="%oneup_uploader.command.clear_orphans.class%">
+                   <tag name="console.command" command="oneup:uploader:clear-orphans" />
                </service>
 
            </services>


### PR DESCRIPTION
Commands need to be registered or the deprecation notice in Symfony 3.4 will become an error in Symfony 4.0