### PR TITLE
Add utility methods to `UploadEvents` to generate mapping-specific event names

### DIFF
--- a/Resources/doc/events.md
+++ b/Resources/doc/events.md
@@ -17,8 +17,17 @@ Moreover this bundles also dispatches some special kind of generic events you ca
 * `oneup_uploader.post_upload.{mapping}`
 * `oneup_uploader.post_persist.{mapping}`
 * `oneup_uploader.post_chunk_upload.{mapping}`
+* `oneup_uploader.validation.{mapping}`
 
 The `{mapping}` part is the key of your configured mapping. The examples in this documentation always uses the mapping key `gallery`. So the dispatched event would be called `oneup_uploader.post_upload.gallery`.
-Using these generic events can save you some time and coding lines, as you don't have to check for the correct type in the `EventListener`.
+Using these generic events can save you some time and coding lines, as you don't have to check for the correct type in the `EventListener`. The `UploadEvents` class provides some utility methods to generate these
+mapping-specific event names. For example:
+
+```php
+public static function getSubscribedEvents()
+{
+    return [UploadEvents::postUpload('gallery') => ['onPostUpload']];
+}
+```
 
 See the [custom logic section](custom_logic.md) of this documentation for specific examples on how to use these Events.

--- a/Tests/UploadEventsTest.php
+++ b/Tests/UploadEventsTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Oneup\UploaderBundle\Tests;
+
+use Oneup\UploaderBundle\UploadEvents;
+use PHPUnit\Framework\TestCase;
+
+class UploadEventsTest extends TestCase
+{
+    public function testPreUploadCanBePassedAMapping()
+    {
+        $event = UploadEvents::preUpload('gallery');
+
+        $this->assertEquals(UploadEvents::PRE_UPLOAD . '.gallery', $event);
+    }
+
+    public function testPostUploadCanBePassedAMapping()
+    {
+        $event = UploadEvents::postUpload('gallery');
+
+        $this->assertEquals(UploadEvents::POST_UPLOAD . '.gallery', $event);
+    }
+
+    public function testPostPersistCanBePassedAMapping()
+    {
+        $event = UploadEvents::postPersist('gallery');
+
+        $this->assertEquals(UploadEvents::POST_PERSIST . '.gallery', $event);
+    }
+
+    public function testPostChunkUploadCanBePassedAMapping()
+    {
+        $event = UploadEvents::postChunkUpload('gallery');
+
+        $this->assertEquals(UploadEvents::POST_CHUNK_UPLOAD . '.gallery', $event);
+    }
+
+    public function testValidationCanBePassedAMapping()
+    {
+        $event = UploadEvents::validation('gallery');
+
+        $this->assertEquals(UploadEvents::VALIDATION . '.gallery', $event);
+    }
+}

--- a/UploadEvents.php
+++ b/UploadEvents.php
@@ -9,4 +9,34 @@ final class UploadEvents
     const POST_PERSIST = 'oneup_uploader.post_persist';
     const POST_CHUNK_UPLOAD = 'oneup_uploader.post_chunk_upload';
     const VALIDATION = 'oneup_uploader.validation';
+
+    public static function preUpload(string $mapping): string
+    {
+        return self::withMapping(self::PRE_UPLOAD, $mapping);
+    }
+
+    public static function postUpload(string $mapping): string
+    {
+        return self::withMapping(self::POST_UPLOAD, $mapping);
+    }
+
+    public static function postPersist(string $mapping): string
+    {
+        return self::withMapping(self::POST_PERSIST, $mapping);
+    }
+
+    public static function postChunkUpload(string $mapping): string
+    {
+        return self::withMapping(self::POST_CHUNK_UPLOAD, $mapping);
+    }
+
+    public static function validation(string $mapping): string
+    {
+        return self::withMapping(self::VALIDATION, $mapping);
+    }
+
+    private static function withMapping(string $event, string $mapping): string
+    {
+        return "{$event}.{$mapping}";
+    }
 }


### PR DESCRIPTION
This PR adds some utility methods to the `UploadEvents` class that generates event names based on the mapping you pass to it (similar to [this](https://github.com/chrisguitarguy/tactician-symfony-events/blob/master/src/CommandEvents.php)). This saves you some typing when using the mapping-specific events in a subscriber:

 E.g. this:

```php
public function getSubscribedEvents()
{
    return [UploadEvents::POST_UPLOAD . '.gallery' => ['onPostUpload']];
}
```

Becomes this:

```php
public function getSubscribedEvents()
{
    return [UploadEvents::postUpload('gallery') => ['onPostUpload']];
}
```

I thought this would be a nice little addition. Feel free to just close the PR if you disagree :).