### PR TITLE
Deprecation removal Symfony 4.2

### DIFF
--- a/Command/ClearChunkCommand.php
+++ b/Command/ClearChunkCommand.php
@@ -2,13 +2,23 @@
 
 namespace Oneup\UploaderBundle\Command;
 
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Oneup\UploaderBundle\Uploader\Chunk\ChunkManager;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class ClearChunkCommand extends ContainerAwareCommand
+class ClearChunkCommand extends Command
 {
     protected static $defaultName = 'oneup:uploader:clear-chunks'; // Make command lazy load
+
+    /** @var ChunkManager */
+    protected $manager;
+
+    public function __construct(ChunkManager $manager, ?string $name = null)
+    {
+        parent::__construct($name);
+        $this->manager = $manager;
+    }
 
     protected function configure()
     {
@@ -20,7 +30,6 @@ class ClearChunkCommand extends ContainerAwareCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $manager = $this->getContainer()->get('oneup_uploader.chunk_manager');
         $manager->clear();
     }
 }

--- a/Command/ClearOrphansCommand.php
+++ b/Command/ClearOrphansCommand.php
@@ -2,13 +2,23 @@
 
 namespace Oneup\UploaderBundle\Command;
 
-use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Oneup\UploaderBundle\Uploader\Orphanage\OrphanageManager;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class ClearOrphansCommand extends ContainerAwareCommand
+class ClearOrphansCommand extends Command
 {
     protected static $defaultName = 'oneup:uploader:clear-orphans'; // Make command lazy load
+
+    /** @var OrphanageManager */
+    protected $manager;
+
+    public function __construct(OrphanageManager $manager, ?string $name = null)
+    {
+        parent::__construct($name);
+        $this->manager = $manager;
+    }
 
     protected function configure()
     {
@@ -20,7 +30,6 @@ class ClearOrphansCommand extends ContainerAwareCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $manager = $this->getContainer()->get('oneup_uploader.orphanage_manager');
         $manager->clear();
     }
 }


### PR DESCRIPTION
ContainerAwareCommand is deprecated since Symfony 4.2. I just replaced it by Command service and then use dependency injection in command controller to make use of ChunkManager or OrphanageManager instead of getting it by container get method.

Fix #354 