### PR TITLE
fix symfony 4.4 "Twig_Extension"

### DIFF
--- a/Twig/Extension/UploaderExtension.php
+++ b/Twig/Extension/UploaderExtension.php
@@ -4,7 +4,10 @@ namespace Oneup\UploaderBundle\Twig\Extension;
 
 use Oneup\UploaderBundle\Templating\Helper\UploaderHelper;
 
-class UploaderExtension extends \Twig_Extension
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+class UploaderExtension extends AbstractExtension
 {
     protected $helper;
 
@@ -21,11 +24,11 @@ class UploaderExtension extends \Twig_Extension
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('oneup_uploader_endpoint', [$this, 'endpoint']),
-            new \Twig_SimpleFunction('oneup_uploader_progress', [$this, 'progress']),
-            new \Twig_SimpleFunction('oneup_uploader_cancel', [$this, 'cancel']),
-            new \Twig_SimpleFunction('oneup_uploader_upload_key', [$this, 'uploadKey']),
-            new \Twig_SimpleFunction('oneup_uploader_maxsize', [$this, 'maxSize']),
+            new TwigFunction('oneup_uploader_endpoint', [$this, 'endpoint']),
+            new TwigFunction('oneup_uploader_progress', [$this, 'progress']),
+            new TwigFunction('oneup_uploader_cancel', [$this, 'cancel']),
+            new TwigFunction('oneup_uploader_upload_key', [$this, 'uploadKey']),
+            new TwigFunction('oneup_uploader_maxsize', [$this, 'maxSize']),
         ];
     }
 


### PR DESCRIPTION
fix Uncaught Error: Class 'Twig_Extension' not found  in symfony 4.4