### PR TITLE
Require symfony/mime directly

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "symfony/event-dispatcher-contracts": "^1.0|^2.0",
         "symfony/finder": "^4.4|^5.0",
         "symfony/framework-bundle": "^4.4|^5.0",
+        "symfony/mime": "^4.4|^5.0",
         "symfony/templating": "^4.4|^5.0",
         "symfony/translation": "^4.4|^5.0",
         "symfony/translation-contracts": "^1.0|^2.0",


### PR DESCRIPTION
`symfony/mime` was required in `symfony/http-foundation` until `5.1`.