### PR TITLE
Update docs with a how-to for php file config

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -160,6 +160,7 @@ some more advanced features.
 * [Template helpers Reference](templating.md)
 * [Configuration Reference](configuration_reference.md)
 * [Testing this bundle](testing.md)
+* [Config based on PHP files](php_config.md)
 
 ## FAQ
 

--- a/doc/php_config.md
+++ b/doc/php_config.md
@@ -1,0 +1,23 @@
+# Config based on PHP files
+
+If you're using Symfony 5 and want to configure this bundle with a PHP file instead of a YAML,
+you can set up the `config/packages/oneup_uploader.php` file like this:
+
+```php
+
+<?php declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+return static function (ContainerConfigurator $configurator): void
+{
+    $configurator->extension('oneup_uploader', [
+        'mappings' => [
+            'gallery' => [
+                'frontend' => 'dropzone'
+            ]
+        ]
+    ]);
+};
+
+```


### PR DESCRIPTION
Symfony 6 will recommend the use of PHP files instead of YAML for config, so it's convenient to show users how to perform PHP config from now on.