### PR TITLE
Make ResponseInterface extends \ArrayAccess

### DIFF
--- a/src/Uploader/Response/ResponseInterface.php
+++ b/src/Uploader/Response/ResponseInterface.php
@@ -4,10 +4,7 @@ declare(strict_types=1);
 
 namespace Oneup\UploaderBundle\Uploader\Response;
 
-/**
- * @mixin \ArrayAccess
- */
-interface ResponseInterface
+interface ResponseInterface extends \ArrayAccess
 {
     /**
      * Transforms this object to an array of data.


### PR DESCRIPTION
As discussed in #389, the ResponseInterface should extend \ArrayAccess. Initially I wanted to use `@extends` so as to to avoid a BC break, however that did not work. Psalm seems to ignore this annotation on interfaces. You can see my [bug report here](https://github.com/vimeo/psalm/issues/4781).

This will require a new major version unfortunately.