### PR TITLE
Add mixin \ArrayAccess annotation to ResponseInterface

### DIFF
--- a/src/Uploader/Response/ResponseInterface.php
+++ b/src/Uploader/Response/ResponseInterface.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Oneup\UploaderBundle\Uploader\Response;
 
+/**
+ * @mixin \ArrayAccess
+ */
 interface ResponseInterface
 {
     /**


### PR DESCRIPTION
After opening #391, I got a response on my [psalm issue](https://github.com/vimeo/psalm/issues/4781). We need to use `@mixin` instead of `@extends`.

This should provide a backwards compatible version of #391.