### PR TITLE
Add native return type declaration to Configuration::getConfigTreeBuilder

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -9,7 +9,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('oneup_uploader');
         $rootNode = $treeBuilder->getRootNode();


### PR DESCRIPTION
Tests report a deprecation warning when using symfony 5.4.

>   Method "Symfony\Component\Config\Definition\ConfigurationInterface::getConfigTreeBuilder()" might add "TreeBuilder" as a native return type declaration in the future. Do the same in implementation "Oneup\UploaderBundle\DependencyInjection\Configuration" now to avoid errors or add an explicit `@return` annotation to suppress this message.
