### PR TITLE
Fix deprecation message return type

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -9,7 +9,7 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('oneup_uploader');
         $rootNode = $treeBuilder->getRootNode();


### PR DESCRIPTION
The interface is hinting that a return type will be set. With this change, a deprecation message will be suppressed.