### PR TITLE
quick fix #422 PHP 8.1 compatibility / deprecation warnings

### DIFF
--- a/src/Uploader/Response/AbstractResponse.php
+++ b/src/Uploader/Response/AbstractResponse.php
@@ -46,6 +46,7 @@ abstract class AbstractResponse implements \ArrayAccess, ResponseInterface
      *
      * @return mixed|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->data[$offset] ?? null;


### PR DESCRIPTION
dirty quick fix for #422 removing the deprecation warning (should work for the 4.x branch, too)