### PR TITLE
Fixed various deprecation fixes for Symfony >6.1, some code changes for PHP >= 8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install the dependencies
-        run: composer install --no-interaction --no-suggest
+        run: composer install --no-interaction
       - name: Check the coding style
         run: vendor/bin/php-cs-fixer fix --diff --dry-run
       - name: Analyze the code
@@ -75,6 +75,6 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install the dependencies
-        run: composer update --prefer-lowest --prefer-stable --no-interaction --no-suggest
+        run: composer update --prefer-lowest --prefer-stable --no-interaction
       - name: Run the unit tests
         run: vendor/bin/phpunit --colors=always

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,80 +1,80 @@
 name: CI
 
 on:
-    pull_request: ~
-    push:
-        branches:
-            - master
-        tags:
-            - '*'
+  pull_request: ~
+  push:
+    branches:
+      - master
+    tags:
+      - '*'
 
 jobs:
-    coding-style:
-        name: Coding Style
-        runs-on: ubuntu-latest
-        steps:
-            - name: Setup PHP
-              uses: shivammathur/setup-php@2.9.0
-              with:
-                  php-version: 7.4
-                  extensions: dom, fileinfo, filter, gd, hash, intl, json, mbstring, pcre, pdo, zlib
-                  coverage: none
+  coding-style:
+    name: Coding Style
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.0
+          extensions: dom, fileinfo, filter, gd, hash, intl, json, mbstring, pcre, pdo, zlib
+          coverage: none
 
-            - name: Checkout
-              uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v3
 
-            - name: Install the dependencies
-              run: composer install --no-interaction --no-suggest
-            - name: Check the coding style
-              run: vendor/bin/php-cs-fixer fix --diff --dry-run
-            - name: Analyze the code
-              run: vendor/bin/phpstan analyze src/ tests/ --level=max
+      - name: Install the dependencies
+        run: composer install --no-interaction --no-suggest
+      - name: Check the coding style
+        run: vendor/bin/php-cs-fixer fix --diff --dry-run
+      - name: Analyze the code
+        run: vendor/bin/phpstan analyze
 
-    tests:
-        name: PHP ${{ matrix.php }} / SF ^${{ matrix.symfony }}
-        runs-on: ubuntu-latest
-        strategy:
-            fail-fast: false
-            matrix:
-                php: [7.4, 8.0]
-                symfony: [4.4, 5.4, 6.0]
-                exclude:
-                    # Symfony 6.0 does not supports php <8.0
-                    - php: 7.4
-                      symfony: 6.0
-        steps:
-            - name: Setup PHP
-              uses: shivammathur/setup-php@2.9.0
-              with:
-                  php-version: ${{ matrix.php }}
-                  extensions: dom, fileinfo, filter, gd, hash, intl, json, mbstring, pcre, pdo_mysql, zlib
-                  coverage: none
+  tests:
+    name: PHP ${{ matrix.php }} / SF ^${{ matrix.symfony }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [8.0, 8.1]
+        symfony: [5.4, 6.0, 6.1]
+        exclude:
+          # Symfony 6.1 does not support php <8.1
+          - php: 8.0
+            symfony: 6.1
+    steps:
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, fileinfo, filter, gd, hash, intl, json, mbstring, pcre, pdo_mysql, zlib
+          coverage: none
 
-            - name: Checkout
-              uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v3
 
-            - name: Install the dependencies
-              run: |
-                composer require symfony/framework-bundle:^${{ matrix.symfony }} symfony/http-foundation:^${{ matrix.symfony }}
-                composer install --no-interaction --no-suggest
-            - name: Run the unit tests
-              run: vendor/bin/phpunit --colors=always
+      - name: Install the dependencies
+        run: |
+          composer require symfony/framework-bundle:^${{ matrix.symfony }} symfony/http-foundation:^${{ matrix.symfony }}
+          composer install --no-interaction --no-suggest
+      - name: Run the unit tests
+        run: vendor/bin/phpunit --colors=always
 
-    prefer-lowest:
-        name: Prefer Lowest
-        runs-on: ubuntu-latest
-        steps:
-            - name: Setup PHP
-              uses: shivammathur/setup-php@2.7.0
-              with:
-                  php-version: 7.4
-                  extensions: dom, fileinfo, filter, gd, hash, intl, json, mbstring, pcre, pdo_mysql, zlib
-                  coverage: none
+  prefer-lowest:
+    name: Prefer Lowest
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.0
+          extensions: dom, fileinfo, filter, gd, hash, intl, json, mbstring, pcre, pdo_mysql, zlib
+          coverage: none
 
-            - name: Checkout
-              uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v3
 
-            - name: Install the dependencies
-              run: composer update --prefer-lowest --prefer-stable --no-interaction --no-suggest
-            - name: Run the unit tests
-              run: vendor/bin/phpunit --colors=always
+      - name: Install the dependencies
+        run: composer update --prefer-lowest --prefer-stable --no-interaction --no-suggest
+      - name: Run the unit tests
+        run: vendor/bin/phpunit --colors=always

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,17 +1,19 @@
 <?php
+use PhpCsFixer\Config;
 
 $finder = PhpCsFixer\Finder::create()
     ->in([__DIR__ . '/src', __DIR__ . '/tests'])
     ->exclude(['App/cache', 'App/var'])
 ;
 
-return PhpCsFixer\Config::create()
+$config = new Config();
+return $config
     ->setRules([
         '@DoctrineAnnotation' => true,
         '@Symfony' => true,
         '@Symfony:risky' => true,
-        '@PHP71Migration' => true,
-        '@PHP71Migration:risky' => true,
+        '@PHP80Migration' => true,
+        '@PHP80Migration:risky' => true,
         '@PHPUnit60Migration:risky' => true,
         '@PHPUnit75Migration:risky' => true,
         'align_multiline_comment' => true,
@@ -21,11 +23,7 @@ return PhpCsFixer\Config::create()
         ],
         'combine_consecutive_issets' => true,
         'combine_consecutive_unsets' => true,
-        'general_phpdoc_annotation_remove' => [
-            'author',
-            'expectedException',
-            'expectedExceptionMessage',
-        ],
+        'general_phpdoc_annotation_remove' => true,
         'heredoc_to_nowdoc' => true,
         'linebreak_after_opening_tag' => true,
         'list_syntax' => ['syntax' => 'short'],

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
         "friendsofphp/php-cs-fixer": "3.22.*",
         "knplabs/gaufrette": "^0.9",
         "oneup/flysystem-bundle": "^4.1",
-        "phpstan/phpstan": "^0.12.10",
+        "phpstan/phpstan": "^1.8",
         "phpunit/phpunit": "^9.5",
         "sensio/framework-extra-bundle": "^5.0 || ^6.0",
         "m2mtech/flysystem-stream-wrapper": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
         "amazonwebservices/aws-sdk-for-php": "1.5.*",
         "doctrine/common": "^2.12 || ^3.0",
         "doctrine/doctrine-bundle": "^2.4",
-        "friendsofphp/php-cs-fixer": "^2.16",
+        "friendsofphp/php-cs-fixer": "3.22.*",
         "knplabs/gaufrette": "^0.9",
         "oneup/flysystem-bundle": "^4.1",
         "phpstan/phpstan": "^0.12.10",

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "symfony/asset": "^4.4 || ^5.4 || ^6.0",
         "symfony/event-dispatcher-contracts": "^1.0 || ^2.0 || ^3.0",
         "symfony/finder": "^4.4 || ^5.4 || ^6.0",

--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
         "sensio/framework-extra-bundle": "^5.0 || ^6.0",
         "m2mtech/flysystem-stream-wrapper": "^1.0",
         "symfony/browser-kit": "^4.4 || ^5.4 || ^6.0",
-        "symfony/phpunit-bridge": "^5.4",
+        "symfony/phpunit-bridge": "6.0.*",
         "symfony/security-bundle": "^4.4 || ^5.4 || ^6.0",
         "symfony/var-dumper": "^4.4 || ^5.4 || ^6.0",
         "twistor/flysystem-stream-wrapper": "^1.0"

--- a/doc/custom_uploader.md
+++ b/doc/custom_uploader.md
@@ -33,14 +33,18 @@ namespace Acme\DemoBundle\Controller;
 use Symfony\Component\HttpFoundation\File\Exception\UploadException;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Oneup\UploaderBundle\Controller\UploaderController;
-use Oneup\UploaderBundle\Uploader\Response\EmptyResponse;
+use Oneup\UploaderBundle\Uploader\Response\EmptyResponse;use Symfony\Component\HttpFoundation\RequestStack;
 
 class CustomUploader extends UploaderController
 {
+
+    public function __construct(protected RequestStack $requestStack) {
+    }
+    
     public function upload()
     {
         // get some basic stuff together
-        $request = $this->container->get('request_stack')->getMasterRequest();
+        $request = $this->requestStack->getMainRequest();
         $response = new EmptyResponse();
         
         // get file from request (your own logic)
@@ -100,7 +104,7 @@ class FineUploaderResponse extends AbstractResponse
     public function assemble()
     {
         // explicitly overwrite success and error key
-        // as these keys are used internaly by the
+        // as these keys are used internally by the
         // frontend uploader
         $data = $this->data;
         $data['success'] = $this->success;

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -15,6 +15,14 @@ parameters:
     reportUnmatchedIgnoredErrors: false
 
     ignoreErrors:
+        - '#Cannot cast mixed to int\.#'
+        - '#Cannot call method addListener\(\) on mixed\.#'
+        - '#Cannot call method getSize\(\) on mixed\.#'
+        - '#Cannot call method maxSize\(\) on mixed\.#'
+        - '#Cannot call method getPathname\(\) on mixed\.#'
+        - '#Cannot call method getPath\(\) on mixed\.#'
+        - '#Cannot call method getRealPath\(\) on mixed\.#'
+        - '#Cannot call method getBasename\(\) on mixed\.#'
         - '#Method Symfony\\Contracts\\EventDispatcher\\EventDispatcherInterface::dispatch\(\) invoked with 2 parameters, 1 required\.#'
         -
             message: '#Parameter \#1 \$parameters of class Symfony\\Component\\HttpFoundation\\FileBag constructor expects array<Symfony\\Component\\HttpFoundation\\File\\UploadedFile>, array<int, Symfony\\Component\\HttpFoundation\\File\\UploadedFile\|null> given\.#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,15 +1,15 @@
 parameters:
-    bootstrapFiles:
-        - %rootDir%/../../../vendor/autoload.php
-
-    excludes_analyse:
+    level: 9
+    paths:
+        - src
+        - tests
+    excludePaths:
         - src/DependencyInjection/Configuration.php
         - tests/App/cache
         - tests/App/logs
         - tests/App/var
         - var
         - vendor
-
     checkGenericClassInNonGenericObjectType: false
     checkMissingIterableValueType: false
     reportUnmatchedIgnoredErrors: false

--- a/src/Command/ClearChunkCommand.php
+++ b/src/Command/ClearChunkCommand.php
@@ -5,14 +5,16 @@ declare(strict_types=1);
 namespace Oneup\UploaderBundle\Command;
 
 use Oneup\UploaderBundle\Uploader\Chunk\ChunkManager;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'oneup:uploader:clear-chunks'
+)]
 class ClearChunkCommand extends Command
 {
-    protected static $defaultName = 'oneup:uploader:clear-chunks'; // Make command lazy load
-
     /**
      * @var ChunkManager
      */

--- a/src/Command/ClearOrphansCommand.php
+++ b/src/Command/ClearOrphansCommand.php
@@ -5,10 +5,14 @@ declare(strict_types=1);
 namespace Oneup\UploaderBundle\Command;
 
 use Oneup\UploaderBundle\Uploader\Orphanage\OrphanageManager;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'oneup:uploader:clear-orphans'
+)]
 class ClearOrphansCommand extends Command
 {
     protected static $defaultName = 'oneup:uploader:clear-orphans';

--- a/src/Controller/AbstractController.php
+++ b/src/Controller/AbstractController.php
@@ -36,8 +36,8 @@ abstract class AbstractController
 
         $session = $request->getSession();
 
-        $prefix = (string) ini_get('session.upload_progress.prefix');
-        $name = (string) ini_get('session.upload_progress.name');
+        $prefix = (string) \ini_get('session.upload_progress.prefix');
+        $name = (string) \ini_get('session.upload_progress.name');
 
         // assemble session key
         // ref: http://php.net/manual/en/session.upload-progress.php
@@ -53,8 +53,8 @@ abstract class AbstractController
 
         $session = $request->getSession();
 
-        $prefix = (string) ini_get('session.upload_progress.prefix');
-        $name = (string) ini_get('session.upload_progress.name');
+        $prefix = (string) \ini_get('session.upload_progress.prefix');
+        $name = (string) \ini_get('session.upload_progress.name');
 
         $key = sprintf('%s.%s', $prefix, $request->get($name));
 
@@ -97,7 +97,7 @@ abstract class AbstractController
      *
      *  Note: The return value differs when
      *
-     *  @param mixed $file The file to upload
+     * @param mixed $file The file to upload
      */
     protected function handleUpload($file, ResponseInterface $response, Request $request): void
     {
@@ -126,9 +126,9 @@ abstract class AbstractController
     /**
      *  This function is a helper function which dispatches pre upload event.
      *
-     *  @param FileInterface $uploaded the uploaded file
-     *  @param ResponseInterface $response a response object
-     *  @param Request $request the request object
+     * @param FileInterface     $uploaded the uploaded file
+     * @param ResponseInterface $response a response object
+     * @param Request           $request  the request object
      */
     protected function dispatchPreUploadEvent(FileInterface $uploaded, ResponseInterface $response, Request $request): void
     {
@@ -142,7 +142,7 @@ abstract class AbstractController
      *  This function is a helper function which dispatches post upload
      *  and post persist events.
      *
-     *  @param mixed $uploaded the uploaded file
+     * @param mixed $uploaded the uploaded file
      */
     protected function dispatchPostEvents($uploaded, ResponseInterface $response, Request $request): void
     {
@@ -171,8 +171,6 @@ abstract class AbstractController
      *
      * On top of that, if the client does not support the application/json type,
      * then the content type of the response will be set to text/plain instead.
-     *
-     * @param mixed $data
      */
     protected function createSupportedJsonResponse($data, int $statusCode = 200): JsonResponse
     {

--- a/src/Controller/AbstractController.php
+++ b/src/Controller/AbstractController.php
@@ -24,38 +24,8 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 abstract class AbstractController
 {
-    /**
-     * @var ErrorHandlerInterface
-     */
-    protected $errorHandler;
-
-    /**
-     * @var ContainerInterface
-     */
-    protected $container;
-
-    /**
-     * @var StorageInterface
-     */
-    protected $storage;
-
-    /**
-     * @var array
-     */
-    protected $config;
-
-    /**
-     * @var string
-     */
-    protected $type;
-
-    public function __construct(ContainerInterface $container, StorageInterface $storage, ErrorHandlerInterface $errorHandler, array $config, string $type)
+    public function __construct(protected ContainerInterface $container, protected StorageInterface $storage, protected ErrorHandlerInterface $errorHandler, protected array $config, protected string $type)
     {
-        $this->errorHandler = $errorHandler;
-        $this->container = $container;
-        $this->storage = $storage;
-        $this->config = $config;
-        $this->type = $type;
     }
 
     abstract public function upload(): JsonResponse;
@@ -223,9 +193,7 @@ abstract class AbstractController
         $requestStack = $this->container->get('request_stack');
 
         /** @var Request $request */
-        $request = method_exists($requestStack, 'getMainRequest')
-            ? $requestStack->getMainRequest()
-            : $requestStack->getMasterRequest();
+        $request = $requestStack->getMainRequest();
 
         return $request;
     }

--- a/src/Controller/BlueimpController.php
+++ b/src/Controller/BlueimpController.php
@@ -39,8 +39,8 @@ class BlueimpController extends AbstractChunkedController
 
         $session = $request->getSession();
 
-        $prefix = (string) ini_get('session.upload_progress.prefix');
-        $name = (string) ini_get('session.upload_progress.name');
+        $prefix = (string) \ini_get('session.upload_progress.prefix');
+        $name = (string) \ini_get('session.upload_progress.name');
 
         // ref: https://github.com/blueimp/jQuery-File-Upload/wiki/PHP-Session-Upload-Progress
         $key = sprintf('%s.%s', $prefix, $request->get($name));

--- a/src/Controller/BlueimpController.php
+++ b/src/Controller/BlueimpController.php
@@ -41,9 +41,11 @@ class BlueimpController extends AbstractChunkedController
 
         $prefix = (string) \ini_get('session.upload_progress.prefix');
         $name = (string) \ini_get('session.upload_progress.name');
+        /** @var string $value */
+        $value = $request->get($name);
 
         // ref: https://github.com/blueimp/jQuery-File-Upload/wiki/PHP-Session-Upload-Progress
-        $key = sprintf('%s.%s', $prefix, $request->get($name));
+        $key = sprintf('%s.%s', $prefix, $value);
         $value = $session->get($key);
 
         $progress = [

--- a/src/Controller/DropzoneController.php
+++ b/src/Controller/DropzoneController.php
@@ -29,7 +29,7 @@ class DropzoneController extends AbstractChunkedController
                     $this->handleUpload($file, $response, $request)
                 ;
             } catch (UploadException $e) {
-                $statusCode = 500; //Dropzone displays error if HTTP response is 40x or 50x
+                $statusCode = 500; // Dropzone displays error if HTTP response is 40x or 50x
                 $this->errorHandler->addException($response, $e);
 
                 /** @var TranslatorInterface $translator */

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -106,9 +106,7 @@ class Configuration implements ConfigurationInterface
                                     ->prototype('scalar')
                                         ->beforeNormalization()
                                             ->ifString()
-                                            ->then(function ($v) {
-                                                return strtolower($v);
-                                            })
+                                            ->then(fn ($v) => strtolower($v))
                                         ->end()
                                     ->end()
                                 ->end()

--- a/src/DependencyInjection/OneupUploaderExtension.php
+++ b/src/DependencyInjection/OneupUploaderExtension.php
@@ -81,7 +81,7 @@ class OneupUploaderExtension extends Extension
         ;
     }
 
-    protected function processMapping(string $key, array &$mapping): array
+    protected function processMapping(string $key, array & $mapping): array
     {
         $mapping['max_size'] = $mapping['max_size'] < 0 || \is_string($mapping['max_size']) ?
             $this->getMaxUploadSize($mapping['max_size']) :
@@ -188,7 +188,7 @@ class OneupUploaderExtension extends Extension
         }
     }
 
-    protected function createStorageService(array &$config, string $key, bool $orphanage = false): Reference
+    protected function createStorageService(array & $config, string $key, bool $orphanage = false): Reference
     {
         $storageService = null;
 

--- a/src/DependencyInjection/OneupUploaderExtension.php
+++ b/src/DependencyInjection/OneupUploaderExtension.php
@@ -81,7 +81,7 @@ class OneupUploaderExtension extends Extension
         ;
     }
 
-    protected function processMapping(string $key, array & $mapping): array
+    protected function processMapping(string $key, array &$mapping): array
     {
         $mapping['max_size'] = $mapping['max_size'] < 0 || \is_string($mapping['max_size']) ?
             $this->getMaxUploadSize($mapping['max_size']) :
@@ -188,7 +188,7 @@ class OneupUploaderExtension extends Extension
         }
     }
 
-    protected function createStorageService(array & $config, string $key, bool $orphanage = false): Reference
+    protected function createStorageService(array &$config, string $key, bool $orphanage = false): Reference
     {
         $storageService = null;
 
@@ -271,7 +271,7 @@ class OneupUploaderExtension extends Extension
                 break;
         }
 
-        if (\strlen($filesystem) <= 0) {
+        if ('' === $filesystem) {
             throw new ServiceNotFoundException('Empty service name');
         }
 
@@ -285,14 +285,11 @@ class OneupUploaderExtension extends Extension
             ->addArgument($prefix);
     }
 
-    /**
-     * @param mixed $input
-     */
     protected function getMaxUploadSize($input): int
     {
         $input = $this->getValueInBytes($input);
-        $maxPost = $this->getValueInBytes(ini_get('upload_max_filesize'));
-        $maxFile = $this->getValueInBytes(ini_get('post_max_size'));
+        $maxPost = $this->getValueInBytes(\ini_get('upload_max_filesize'));
+        $maxFile = $this->getValueInBytes(\ini_get('post_max_size'));
 
         if ($input < 0) {
             return min($maxPost, $maxFile);
@@ -301,9 +298,6 @@ class OneupUploaderExtension extends Extension
         return min(min($input, $maxPost), $maxFile);
     }
 
-    /**
-     * @param mixed $input
-     */
     protected function getValueInBytes($input): int
     {
         // see: http://www.php.net/manual/en/function.ini-get.php
@@ -313,12 +307,12 @@ class OneupUploaderExtension extends Extension
 
         switch ($last) {
             case 'g': $numericInput *= 1024;
-            // no break
+                // no break
             case 'm': $numericInput *= 1024;
-            // no break
+                // no break
             case 'k': $numericInput *= 1024;
 
-            return (int) $numericInput;
+                return (int) $numericInput;
         }
 
         return (int) $input;

--- a/src/Event/PostChunkUploadEvent.php
+++ b/src/Event/PostChunkUploadEvent.php
@@ -14,52 +14,20 @@ class PostChunkUploadEvent extends Event
     public const NAME = UploadEvents::POST_CHUNK_UPLOAD;
 
     /**
-     * @var mixed
-     */
-    protected $chunk;
-
-    /**
-     * @var Request
-     */
-    protected $request;
-
-    /**
-     * @var string
-     */
-    protected $type;
-
-    /**
-     * @var ResponseInterface
-     */
-    protected $response;
-
-    /**
-     * @var array
-     */
-    protected $config;
-
-    /**
-     * @var bool
-     */
-    protected $isLast;
-
-    /**
      * @param mixed $chunk
+     * @param ResponseInterface $response
+     * @param Request $request
+     * @param bool $isLast
+     * @param string $type
+     * @param array $config
      */
-    public function __construct($chunk, ResponseInterface $response, Request $request, bool $isLast, string $type, array $config)
-    {
-        $this->chunk = $chunk;
-        $this->request = $request;
-        $this->response = $response;
-        $this->isLast = $isLast;
-        $this->type = $type;
-        $this->config = $config;
+    public function __construct(protected mixed $chunk, protected ResponseInterface $response, protected Request $request, protected bool $isLast, protected string $type, protected array $config) {
     }
 
     /**
      * @return mixed
      */
-    public function getChunk()
+    public function getChunk(): mixed
     {
         return $this->chunk;
     }

--- a/src/Event/PostChunkUploadEvent.php
+++ b/src/Event/PostChunkUploadEvent.php
@@ -13,14 +13,6 @@ class PostChunkUploadEvent extends Event
 {
     public const NAME = UploadEvents::POST_CHUNK_UPLOAD;
 
-    /**
-     * @param mixed             $chunk
-     * @param ResponseInterface $response
-     * @param Request           $request
-     * @param bool              $isLast
-     * @param string            $type
-     * @param array             $config
-     */
     public function __construct(protected mixed $chunk, protected ResponseInterface $response, protected Request $request, protected bool $isLast, protected string $type, protected array $config)
     {
     }

--- a/src/Event/PostChunkUploadEvent.php
+++ b/src/Event/PostChunkUploadEvent.php
@@ -14,19 +14,17 @@ class PostChunkUploadEvent extends Event
     public const NAME = UploadEvents::POST_CHUNK_UPLOAD;
 
     /**
-     * @param mixed $chunk
+     * @param mixed             $chunk
      * @param ResponseInterface $response
-     * @param Request $request
-     * @param bool $isLast
-     * @param string $type
-     * @param array $config
+     * @param Request           $request
+     * @param bool              $isLast
+     * @param string            $type
+     * @param array             $config
      */
-    public function __construct(protected mixed $chunk, protected ResponseInterface $response, protected Request $request, protected bool $isLast, protected string $type, protected array $config) {
+    public function __construct(protected mixed $chunk, protected ResponseInterface $response, protected Request $request, protected bool $isLast, protected string $type, protected array $config)
+    {
     }
 
-    /**
-     * @return mixed
-     */
     public function getChunk(): mixed
     {
         return $this->chunk;

--- a/src/Event/PostPersistEvent.php
+++ b/src/Event/PostPersistEvent.php
@@ -16,40 +16,13 @@ class PostPersistEvent extends Event
     public const NAME = UploadEvents::POST_PERSIST;
 
     /**
-     * @var FileInterface|File
-     */
-    protected $file;
-
-    /**
-     * @var Request
-     */
-    protected $request;
-
-    /**
-     * @var string
-     */
-    protected $type;
-
-    /**
-     * @var ResponseInterface
-     */
-    protected $response;
-
-    /**
-     * @var array
-     */
-    protected $config;
-
-    /**
      * @param FileInterface|File $file
+     * @param ResponseInterface $response
+     * @param Request $request
+     * @param string $type
+     * @param array $config
      */
-    public function __construct($file, ResponseInterface $response, Request $request, string $type, array $config)
-    {
-        $this->file = $file;
-        $this->request = $request;
-        $this->response = $response;
-        $this->type = $type;
-        $this->config = $config;
+    public function __construct(protected FileInterface|File $file, protected ResponseInterface $response, protected Request $request, protected string $type, protected array $config) {
     }
 
     /**

--- a/src/Event/PostPersistEvent.php
+++ b/src/Event/PostPersistEvent.php
@@ -15,14 +15,7 @@ class PostPersistEvent extends Event
 {
     public const NAME = UploadEvents::POST_PERSIST;
 
-    /**
-     * @param FileInterface|File $file
-     * @param ResponseInterface  $response
-     * @param Request            $request
-     * @param string             $type
-     * @param array              $config
-     */
-    public function __construct(protected FileInterface | File $file, protected ResponseInterface $response, protected Request $request, protected string $type, protected array $config)
+    public function __construct(protected FileInterface|File $file, protected ResponseInterface $response, protected Request $request, protected string $type, protected array $config)
     {
     }
 

--- a/src/Event/PostPersistEvent.php
+++ b/src/Event/PostPersistEvent.php
@@ -17,12 +17,13 @@ class PostPersistEvent extends Event
 
     /**
      * @param FileInterface|File $file
-     * @param ResponseInterface $response
-     * @param Request $request
-     * @param string $type
-     * @param array $config
+     * @param ResponseInterface  $response
+     * @param Request            $request
+     * @param string             $type
+     * @param array              $config
      */
-    public function __construct(protected FileInterface|File $file, protected ResponseInterface $response, protected Request $request, protected string $type, protected array $config) {
+    public function __construct(protected FileInterface | File $file, protected ResponseInterface $response, protected Request $request, protected string $type, protected array $config)
+    {
     }
 
     /**

--- a/src/Event/PostUploadEvent.php
+++ b/src/Event/PostUploadEvent.php
@@ -16,40 +16,13 @@ class PostUploadEvent extends Event
     public const NAME = UploadEvents::POST_UPLOAD;
 
     /**
-     * @var FileInterface|File
-     */
-    protected $file;
-
-    /**
-     * @var Request
-     */
-    protected $request;
-
-    /**
-     * @var string
-     */
-    protected $type;
-
-    /**
-     * @var ResponseInterface
-     */
-    protected $response;
-
-    /**
-     * @var array
-     */
-    protected $config;
-
-    /**
      * @param FileInterface|File $file
+     * @param ResponseInterface $response
+     * @param Request $request
+     * @param string $type
+     * @param array $config
      */
-    public function __construct($file, ResponseInterface $response, Request $request, string $type, array $config)
-    {
-        $this->file = $file;
-        $this->request = $request;
-        $this->response = $response;
-        $this->type = $type;
-        $this->config = $config;
+    public function __construct(protected FileInterface|File $file, protected ResponseInterface $response, protected Request $request, protected string $type, protected array $config) {
     }
 
     /**

--- a/src/Event/PostUploadEvent.php
+++ b/src/Event/PostUploadEvent.php
@@ -15,14 +15,7 @@ class PostUploadEvent extends Event
 {
     public const NAME = UploadEvents::POST_UPLOAD;
 
-    /**
-     * @param FileInterface|File $file
-     * @param ResponseInterface  $response
-     * @param Request            $request
-     * @param string             $type
-     * @param array              $config
-     */
-    public function __construct(protected FileInterface | File $file, protected ResponseInterface $response, protected Request $request, protected string $type, protected array $config)
+    public function __construct(protected FileInterface|File $file, protected ResponseInterface $response, protected Request $request, protected string $type, protected array $config)
     {
     }
 

--- a/src/Event/PostUploadEvent.php
+++ b/src/Event/PostUploadEvent.php
@@ -17,12 +17,13 @@ class PostUploadEvent extends Event
 
     /**
      * @param FileInterface|File $file
-     * @param ResponseInterface $response
-     * @param Request $request
-     * @param string $type
-     * @param array $config
+     * @param ResponseInterface  $response
+     * @param Request            $request
+     * @param string             $type
+     * @param array              $config
      */
-    public function __construct(protected FileInterface|File $file, protected ResponseInterface $response, protected Request $request, protected string $type, protected array $config) {
+    public function __construct(protected FileInterface | File $file, protected ResponseInterface $response, protected Request $request, protected string $type, protected array $config)
+    {
     }
 
     /**

--- a/src/Event/PreUploadEvent.php
+++ b/src/Event/PreUploadEvent.php
@@ -17,12 +17,13 @@ class PreUploadEvent extends Event
 
     /**
      * @param File|FileInterface $file
-     * @param ResponseInterface $response
-     * @param Request $request
-     * @param string $type
-     * @param array $config
+     * @param ResponseInterface  $response
+     * @param Request            $request
+     * @param string             $type
+     * @param array              $config
      */
-    public function __construct(protected File|FileInterface $file, protected ResponseInterface $response, protected Request $request, protected string $type, protected array $config) {
+    public function __construct(protected File | FileInterface $file, protected ResponseInterface $response, protected Request $request, protected string $type, protected array $config)
+    {
     }
 
     /**

--- a/src/Event/PreUploadEvent.php
+++ b/src/Event/PreUploadEvent.php
@@ -15,14 +15,7 @@ class PreUploadEvent extends Event
 {
     public const NAME = UploadEvents::PRE_UPLOAD;
 
-    /**
-     * @param File|FileInterface $file
-     * @param ResponseInterface  $response
-     * @param Request            $request
-     * @param string             $type
-     * @param array              $config
-     */
-    public function __construct(protected File | FileInterface $file, protected ResponseInterface $response, protected Request $request, protected string $type, protected array $config)
+    public function __construct(protected File|FileInterface $file, protected ResponseInterface $response, protected Request $request, protected string $type, protected array $config)
     {
     }
 

--- a/src/Event/PreUploadEvent.php
+++ b/src/Event/PreUploadEvent.php
@@ -16,40 +16,13 @@ class PreUploadEvent extends Event
     public const NAME = UploadEvents::PRE_UPLOAD;
 
     /**
-     * @var FileInterface|File
+     * @param File|FileInterface $file
+     * @param ResponseInterface $response
+     * @param Request $request
+     * @param string $type
+     * @param array $config
      */
-    protected $file;
-
-    /**
-     * @var Request
-     */
-    protected $request;
-
-    /**
-     * @var string
-     */
-    protected $type;
-
-    /**
-     * @var ResponseInterface
-     */
-    protected $response;
-
-    /**
-     * @var array
-     */
-    protected $config;
-
-    /**
-     * @param FileInterface|File $file
-     */
-    public function __construct($file, ResponseInterface $response, Request $request, string $type, array $config)
-    {
-        $this->file = $file;
-        $this->request = $request;
-        $this->response = $response;
-        $this->type = $type;
-        $this->config = $config;
+    public function __construct(protected File|FileInterface $file, protected ResponseInterface $response, protected Request $request, protected string $type, protected array $config) {
     }
 
     /**

--- a/src/Event/ValidationEvent.php
+++ b/src/Event/ValidationEvent.php
@@ -16,40 +16,13 @@ class ValidationEvent extends Event
     public const NAME = UploadEvents::VALIDATION;
 
     /**
-     * @var FileInterface|File
-     */
-    protected $file;
-
-    /**
-     * @var array
-     */
-    protected $config;
-
-    /**
-     * @var string
-     */
-    protected $type;
-
-    /**
-     * @var Request
-     */
-    protected $request;
-
-    /**
-     * @var ResponseInterface|null
-     */
-    protected $response;
-
-    /**
      * @param FileInterface|File $file
+     * @param Request $request
+     * @param array $config
+     * @param string $type
+     * @param ResponseInterface|null $response
      */
-    public function __construct($file, Request $request, array $config, string $type, ResponseInterface $response = null)
-    {
-        $this->file = $file;
-        $this->config = $config;
-        $this->type = $type;
-        $this->request = $request;
-        $this->response = $response;
+    public function __construct(protected FileInterface|File $file, protected Request $request, protected array $config, protected string $type, protected ?ResponseInterface $response = null) {
     }
 
     /**

--- a/src/Event/ValidationEvent.php
+++ b/src/Event/ValidationEvent.php
@@ -15,14 +15,7 @@ class ValidationEvent extends Event
 {
     public const NAME = UploadEvents::VALIDATION;
 
-    /**
-     * @param FileInterface|File     $file
-     * @param Request                $request
-     * @param array                  $config
-     * @param string                 $type
-     * @param ResponseInterface|null $response
-     */
-    public function __construct(protected FileInterface | File $file, protected Request $request, protected array $config, protected string $type, protected ?ResponseInterface $response = null)
+    public function __construct(protected FileInterface|File $file, protected Request $request, protected array $config, protected string $type, protected ?ResponseInterface $response = null)
     {
     }
 

--- a/src/Event/ValidationEvent.php
+++ b/src/Event/ValidationEvent.php
@@ -16,13 +16,14 @@ class ValidationEvent extends Event
     public const NAME = UploadEvents::VALIDATION;
 
     /**
-     * @param FileInterface|File $file
-     * @param Request $request
-     * @param array $config
-     * @param string $type
+     * @param FileInterface|File     $file
+     * @param Request                $request
+     * @param array                  $config
+     * @param string                 $type
      * @param ResponseInterface|null $response
      */
-    public function __construct(protected FileInterface|File $file, protected Request $request, protected array $config, protected string $type, protected ?ResponseInterface $response = null) {
+    public function __construct(protected FileInterface | File $file, protected Request $request, protected array $config, protected string $type, protected ?ResponseInterface $response = null)
+    {
     }
 
     /**

--- a/src/Routing/RouteLoader.php
+++ b/src/Routing/RouteLoader.php
@@ -10,14 +10,9 @@ use Symfony\Component\Routing\RouteCollection;
 
 class RouteLoader extends Loader
 {
-    /**
-     * @var array
-     */
-    protected $controllers;
 
-    public function __construct(array $controllers)
-    {
-        $this->controllers = $controllers;
+    public function __construct(protected array $controllers) {
+        parent::__construct();
     }
 
     /**

--- a/src/Routing/RouteLoader.php
+++ b/src/Routing/RouteLoader.php
@@ -10,8 +10,8 @@ use Symfony\Component\Routing\RouteCollection;
 
 class RouteLoader extends Loader
 {
-
-    public function __construct(protected array $controllers) {
+    public function __construct(protected array $controllers)
+    {
         parent::__construct();
     }
 

--- a/src/Routing/RouteLoader.php
+++ b/src/Routing/RouteLoader.php
@@ -16,7 +16,6 @@ class RouteLoader extends Loader
     }
 
     /**
-     * @param mixed       $resource
      * @param string|null $type
      */
     public function supports($resource, $type = null): bool
@@ -25,7 +24,6 @@ class RouteLoader extends Loader
     }
 
     /**
-     * @param mixed       $resource
      * @param string|null $type
      */
     public function load($resource, $type = null): RouteCollection

--- a/src/Templating/Helper/UploaderHelper.php
+++ b/src/Templating/Helper/UploaderHelper.php
@@ -11,9 +11,10 @@ class UploaderHelper extends Helper
 {
     /**
      * @param RouterInterface $router
-     * @param array $maxsize
+     * @param array           $maxsize
      */
-    public function __construct(protected RouterInterface $router, protected array $maxsize) {
+    public function __construct(protected RouterInterface $router, protected array $maxsize)
+    {
     }
 
     public function getName(): string

--- a/src/Templating/Helper/UploaderHelper.php
+++ b/src/Templating/Helper/UploaderHelper.php
@@ -10,19 +10,10 @@ use Symfony\Component\Templating\Helper\Helper;
 class UploaderHelper extends Helper
 {
     /**
-     * @var RouterInterface
+     * @param RouterInterface $router
+     * @param array $maxsize
      */
-    protected $router;
-
-    /**
-     * @var array
-     */
-    protected $maxsize;
-
-    public function __construct(RouterInterface $router, array $maxsize)
-    {
-        $this->router = $router;
-        $this->maxsize = $maxsize;
+    public function __construct(protected RouterInterface $router, protected array $maxsize) {
     }
 
     public function getName(): string

--- a/src/Templating/Helper/UploaderHelper.php
+++ b/src/Templating/Helper/UploaderHelper.php
@@ -9,10 +9,6 @@ use Symfony\Component\Templating\Helper\Helper;
 
 class UploaderHelper extends Helper
 {
-    /**
-     * @param RouterInterface $router
-     * @param array           $maxsize
-     */
     public function __construct(protected RouterInterface $router, protected array $maxsize)
     {
     }
@@ -39,12 +35,9 @@ class UploaderHelper extends Helper
 
     public function uploadKey(): string
     {
-        return (string) ini_get('session.upload_progress.name');
+        return (string) \ini_get('session.upload_progress.name');
     }
 
-    /**
-     * @return mixed
-     */
     public function maxSize(string $key)
     {
         if (!\array_key_exists($key, $this->maxsize)) {

--- a/src/Twig/Extension/UploaderExtension.php
+++ b/src/Twig/Extension/UploaderExtension.php
@@ -11,13 +11,9 @@ use Twig\TwigFunction;
 class UploaderExtension extends AbstractExtension
 {
     /**
-     * @var UploaderHelper
+     * @param UploaderHelper $helper
      */
-    protected $helper;
-
-    public function __construct(UploaderHelper $helper)
-    {
-        $this->helper = $helper;
+    public function __construct(protected UploaderHelper $helper){
     }
 
     public function getName(): string

--- a/src/Twig/Extension/UploaderExtension.php
+++ b/src/Twig/Extension/UploaderExtension.php
@@ -10,9 +10,6 @@ use Twig\TwigFunction;
 
 class UploaderExtension extends AbstractExtension
 {
-    /**
-     * @param UploaderHelper $helper
-     */
     public function __construct(protected UploaderHelper $helper)
     {
     }
@@ -53,9 +50,6 @@ class UploaderExtension extends AbstractExtension
         return $this->helper->uploadKey();
     }
 
-    /**
-     * @return mixed
-     */
     public function maxSize(string $key)
     {
         return $this->helper->maxSize($key);

--- a/src/Twig/Extension/UploaderExtension.php
+++ b/src/Twig/Extension/UploaderExtension.php
@@ -13,7 +13,8 @@ class UploaderExtension extends AbstractExtension
     /**
      * @param UploaderHelper $helper
      */
-    public function __construct(protected UploaderHelper $helper){
+    public function __construct(protected UploaderHelper $helper)
+    {
     }
 
     public function getName(): string

--- a/src/Uploader/Chunk/ChunkManager.php
+++ b/src/Uploader/Chunk/ChunkManager.php
@@ -9,10 +9,6 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class ChunkManager implements ChunkManagerInterface
 {
-    /**
-     * @param array                 $configuration
-     * @param ChunkStorageInterface $storage
-     */
     public function __construct(protected array $configuration, protected ChunkStorageInterface $storage)
     {
     }

--- a/src/Uploader/Chunk/ChunkManager.php
+++ b/src/Uploader/Chunk/ChunkManager.php
@@ -10,19 +10,10 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 class ChunkManager implements ChunkManagerInterface
 {
     /**
-     * @var array
+     * @param array $configuration
+     * @param ChunkStorageInterface $storage
      */
-    protected $configuration;
-
-    /**
-     * @var ChunkStorageInterface
-     */
-    protected $storage;
-
-    public function __construct(array $configuration, ChunkStorageInterface $storage)
-    {
-        $this->configuration = $configuration;
-        $this->storage = $storage;
+    public function __construct(protected array $configuration, protected ChunkStorageInterface $storage) {
     }
 
     public function clear(): void

--- a/src/Uploader/Chunk/ChunkManager.php
+++ b/src/Uploader/Chunk/ChunkManager.php
@@ -10,10 +10,11 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 class ChunkManager implements ChunkManagerInterface
 {
     /**
-     * @param array $configuration
+     * @param array                 $configuration
      * @param ChunkStorageInterface $storage
      */
-    public function __construct(protected array $configuration, protected ChunkStorageInterface $storage) {
+    public function __construct(protected array $configuration, protected ChunkStorageInterface $storage)
+    {
     }
 
     public function clear(): void

--- a/src/Uploader/Chunk/ChunkManager.php
+++ b/src/Uploader/Chunk/ChunkManager.php
@@ -9,6 +9,10 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class ChunkManager implements ChunkManagerInterface
 {
+    /**
+     * @param array                 $configuration
+     * @param ChunkStorageInterface $storage
+     */
     public function __construct(protected array $configuration, protected ChunkStorageInterface $storage)
     {
     }
@@ -18,12 +22,12 @@ class ChunkManager implements ChunkManagerInterface
         $this->storage->clear($this->configuration['maxage']);
     }
 
-    public function addChunk(string $uuid, int $index, UploadedFile $chunk, string $original)
+    public function addChunk(string $uuid, int $index, UploadedFile $chunk, string $original): mixed
     {
         return $this->storage->addChunk($uuid, $index, $chunk, $original);
     }
 
-    public function assembleChunks($chunks, $removeChunk = true, $renameChunk = false)
+    public function assembleChunks($chunks, $removeChunk = true, $renameChunk = false): mixed
     {
         return $this->storage->assembleChunks($chunks, $removeChunk, $renameChunk);
     }
@@ -33,7 +37,7 @@ class ChunkManager implements ChunkManagerInterface
         $this->storage->cleanup($path);
     }
 
-    public function getChunks(string $uuid)
+    public function getChunks(string $uuid): mixed
     {
         return $this->storage->getChunks($uuid);
     }

--- a/src/Uploader/Chunk/ChunkManagerInterface.php
+++ b/src/Uploader/Chunk/ChunkManagerInterface.php
@@ -11,26 +11,19 @@ interface ChunkManagerInterface
 {
     /**
      * Adds a new Chunk to a given uuid.
-     *
-     * @return mixed
      */
     public function addChunk(string $uuid, int $index, UploadedFile $chunk, string $original);
 
     /**
      * Assembles the given chunks and return the resulting file.
      *
-     * @param mixed $chunks
-     * @param bool  $removeChunk remove the chunk file once its assembled
-     * @param bool  $renameChunk rename the chunk file once its assembled
-     *
-     * @return mixed
+     * @param bool $removeChunk remove the chunk file once its assembled
+     * @param bool $renameChunk rename the chunk file once its assembled
      */
     public function assembleChunks($chunks, $removeChunk = true, $renameChunk = false);
 
     /**
      * Get chunks associated with the given uuid.
-     *
-     * @return mixed
      */
     public function getChunks(string $uuid);
 

--- a/src/Uploader/Chunk/Storage/ChunkStorageInterface.php
+++ b/src/Uploader/Chunk/Storage/ChunkStorageInterface.php
@@ -10,22 +10,11 @@ interface ChunkStorageInterface
 {
     public function clear(int $maxAge): void;
 
-    /**
-     * @return mixed
-     */
     public function addChunk(string $uuid, int $index, UploadedFile $chunk, string $original);
 
-    /**
-     * @param mixed $chunks
-     *
-     * @return mixed
-     */
     public function assembleChunks($chunks, bool $removeChunk, bool $renameChunk);
 
     public function cleanup(string $path): void;
 
-    /**
-     * @return mixed
-     */
     public function getChunks(string $uuid);
 }

--- a/src/Uploader/Chunk/Storage/FilesystemStorage.php
+++ b/src/Uploader/Chunk/Storage/FilesystemStorage.php
@@ -12,9 +12,6 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class FilesystemStorage implements ChunkStorageInterface
 {
-    /**
-     * @param string $directory
-     */
     public function __construct(protected string $directory)
     {
     }

--- a/src/Uploader/Chunk/Storage/FilesystemStorage.php
+++ b/src/Uploader/Chunk/Storage/FilesystemStorage.php
@@ -13,13 +13,9 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 class FilesystemStorage implements ChunkStorageInterface
 {
     /**
-     * @var string
+     * @param string $directory
      */
-    protected $directory;
-
-    public function __construct(string $directory)
-    {
-        $this->directory = $directory;
+    public function __construct(protected string $directory) {
     }
 
     public function clear(int $maxAge): void

--- a/src/Uploader/Chunk/Storage/FilesystemStorage.php
+++ b/src/Uploader/Chunk/Storage/FilesystemStorage.php
@@ -15,7 +15,8 @@ class FilesystemStorage implements ChunkStorageInterface
     /**
      * @param string $directory
      */
-    public function __construct(protected string $directory) {
+    public function __construct(protected string $directory)
+    {
     }
 
     public function clear(int $maxAge): void

--- a/src/Uploader/Chunk/Storage/FlysystemStorage.php
+++ b/src/Uploader/Chunk/Storage/FlysystemStorage.php
@@ -14,36 +14,17 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 class FlysystemStorage implements ChunkStorageInterface
 {
     /**
-     * @var int
-     */
-    public $bufferSize;
-
-    /**
-     * @var array
+     * @var array|null
      */
     protected $unhandledChunk;
 
     /**
-     * @var string
+     * @param Filesystem $filesystem
+     * @param int $bufferSize
+     * @param string $streamWrapperPrefix
+     * @param string $prefix
      */
-    protected $prefix;
-
-    /**
-     * @var string
-     */
-    protected $streamWrapperPrefix;
-
-    /**
-     * @var FilesystemOperator
-     */
-    private $filesystem;
-
-    public function __construct(Filesystem $filesystem, int $bufferSize, string $streamWrapperPrefix, string $prefix)
-    {
-        $this->filesystem = $filesystem;
-        $this->bufferSize = $bufferSize;
-        $this->prefix = $prefix;
-        $this->streamWrapperPrefix = $streamWrapperPrefix;
+    public function __construct(protected Filesystem $filesystem, public int $bufferSize, protected string $streamWrapperPrefix, protected string $prefix) {
     }
 
     public function addChunk(string $uuid, int $index, UploadedFile $chunk, string $original): void

--- a/src/Uploader/Chunk/Storage/FlysystemStorage.php
+++ b/src/Uploader/Chunk/Storage/FlysystemStorage.php
@@ -13,9 +13,6 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class FlysystemStorage implements ChunkStorageInterface
 {
-    /**
-     * @var array
-     */
     protected array $unhandledChunk = [];
 
     public function __construct(protected Filesystem $filesystem, public int $bufferSize, protected string $streamWrapperPrefix, protected string $prefix)

--- a/src/Uploader/Chunk/Storage/FlysystemStorage.php
+++ b/src/Uploader/Chunk/Storage/FlysystemStorage.php
@@ -20,11 +20,12 @@ class FlysystemStorage implements ChunkStorageInterface
 
     /**
      * @param Filesystem $filesystem
-     * @param int $bufferSize
-     * @param string $streamWrapperPrefix
-     * @param string $prefix
+     * @param int        $bufferSize
+     * @param string     $streamWrapperPrefix
+     * @param string     $prefix
      */
-    public function __construct(protected Filesystem $filesystem, public int $bufferSize, protected string $streamWrapperPrefix, protected string $prefix) {
+    public function __construct(protected Filesystem $filesystem, public int $bufferSize, protected string $streamWrapperPrefix, protected string $prefix)
+    {
     }
 
     public function addChunk(string $uuid, int $index, UploadedFile $chunk, string $original): void

--- a/src/Uploader/Chunk/Storage/FlysystemStorage.php
+++ b/src/Uploader/Chunk/Storage/FlysystemStorage.php
@@ -18,12 +18,6 @@ class FlysystemStorage implements ChunkStorageInterface
      */
     protected $unhandledChunk;
 
-    /**
-     * @param Filesystem $filesystem
-     * @param int        $bufferSize
-     * @param string     $streamWrapperPrefix
-     * @param string     $prefix
-     */
     public function __construct(protected Filesystem $filesystem, public int $bufferSize, protected string $streamWrapperPrefix, protected string $prefix)
     {
     }
@@ -150,7 +144,7 @@ class FlysystemStorage implements ChunkStorageInterface
         $uuid = basename($uuid);
 
         return $this->filesystem->listContents($this->prefix . '/' . $uuid)
-            ->filter(function (StorageAttributes $attributes) { return $attributes->isFile(); })
+            ->filter(fn (StorageAttributes $attributes) => $attributes->isFile())
             ->sortByPath()
             ->map(function (StorageAttributes $attributes) {
                 return [

--- a/src/Uploader/Chunk/Storage/FlysystemStorage.php
+++ b/src/Uploader/Chunk/Storage/FlysystemStorage.php
@@ -14,9 +14,9 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 class FlysystemStorage implements ChunkStorageInterface
 {
     /**
-     * @var array|null
+     * @var array
      */
-    protected $unhandledChunk;
+    protected array $unhandledChunk = [];
 
     public function __construct(protected Filesystem $filesystem, public int $bufferSize, protected string $streamWrapperPrefix, protected string $prefix)
     {

--- a/src/Uploader/Chunk/Storage/GaufretteStorage.php
+++ b/src/Uploader/Chunk/Storage/GaufretteStorage.php
@@ -21,16 +21,12 @@ class GaufretteStorage extends StreamManager implements ChunkStorageInterface
     protected $unhandledChunk;
 
     /**
-     * @var string
+     * @param FilesystemInterface $filesystem
+     * @param int $bufferSize
+     * @param string|null $streamWrapperPrefix
+     * @param string $prefix
      */
-    protected $prefix;
-
-    /**
-     * @var string|null
-     */
-    protected $streamWrapperPrefix;
-
-    public function __construct(FilesystemInterface $filesystem, int $bufferSize, ?string $streamWrapperPrefix, string $prefix)
+    public function __construct(FilesystemInterface $filesystem, int $bufferSize, protected ?string $streamWrapperPrefix, protected string $prefix)
     {
         $base = interface_exists(FilesystemInterface::class)
             ? FilesystemInterface::class
@@ -45,8 +41,6 @@ class GaufretteStorage extends StreamManager implements ChunkStorageInterface
         }
         $this->filesystem = $filesystem;
         $this->buffersize = $bufferSize;
-        $this->prefix = $prefix;
-        $this->streamWrapperPrefix = $streamWrapperPrefix;
     }
 
     /**

--- a/src/Uploader/Chunk/Storage/GaufretteStorage.php
+++ b/src/Uploader/Chunk/Storage/GaufretteStorage.php
@@ -21,10 +21,8 @@ class GaufretteStorage extends StreamManager implements ChunkStorageInterface
     protected $unhandledChunk;
 
     /**
-     * @param FilesystemInterface $filesystem
-     * @param int $bufferSize
      * @param string|null $streamWrapperPrefix
-     * @param string $prefix
+     * @param string      $prefix
      */
     public function __construct(FilesystemInterface $filesystem, int $bufferSize, protected ?string $streamWrapperPrefix, protected string $prefix)
     {

--- a/src/Uploader/Chunk/Storage/GaufretteStorage.php
+++ b/src/Uploader/Chunk/Storage/GaufretteStorage.php
@@ -20,10 +20,6 @@ class GaufretteStorage extends StreamManager implements ChunkStorageInterface
      */
     protected $unhandledChunk;
 
-    /**
-     * @param string|null $streamWrapperPrefix
-     * @param string      $prefix
-     */
     public function __construct(FilesystemInterface $filesystem, int $bufferSize, protected ?string $streamWrapperPrefix, protected string $prefix)
     {
         $base = interface_exists(FilesystemInterface::class)
@@ -31,7 +27,7 @@ class GaufretteStorage extends StreamManager implements ChunkStorageInterface
             : Filesystem::class;
 
         if (!$filesystem instanceof $base) {
-            throw new \InvalidArgumentException(sprintf('Expected an instance of "%s", got "%s".', $base, \get_class($filesystem)));
+            throw new \InvalidArgumentException(sprintf('Expected an instance of "%s", got "%s".', $base, $filesystem::class));
         }
 
         if ($filesystem instanceof Filesystem && !($filesystem->getAdapter() instanceof StreamFactory)) {

--- a/src/Uploader/ErrorHandler/BlueimpErrorHandler.php
+++ b/src/Uploader/ErrorHandler/BlueimpErrorHandler.php
@@ -13,7 +13,8 @@ class BlueimpErrorHandler implements ErrorHandlerInterface
     /**
      * @param TranslatorInterface $translator
      */
-    public function __construct(private  TranslatorInterface $translator){
+    public function __construct(private TranslatorInterface $translator)
+    {
     }
 
     public function addException(AbstractResponse $response, Exception $exception): void

--- a/src/Uploader/ErrorHandler/BlueimpErrorHandler.php
+++ b/src/Uploader/ErrorHandler/BlueimpErrorHandler.php
@@ -11,13 +11,9 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class BlueimpErrorHandler implements ErrorHandlerInterface
 {
     /**
-     * @var TranslatorInterface
+     * @param TranslatorInterface $translator
      */
-    private $translator;
-
-    public function __construct(TranslatorInterface $translator)
-    {
-        $this->translator = $translator;
+    public function __construct(private  TranslatorInterface $translator){
     }
 
     public function addException(AbstractResponse $response, Exception $exception): void

--- a/src/Uploader/ErrorHandler/BlueimpErrorHandler.php
+++ b/src/Uploader/ErrorHandler/BlueimpErrorHandler.php
@@ -4,20 +4,16 @@ declare(strict_types=1);
 
 namespace Oneup\UploaderBundle\Uploader\ErrorHandler;
 
-use Exception;
 use Oneup\UploaderBundle\Uploader\Response\AbstractResponse;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class BlueimpErrorHandler implements ErrorHandlerInterface
 {
-    /**
-     * @param TranslatorInterface $translator
-     */
     public function __construct(private TranslatorInterface $translator)
     {
     }
 
-    public function addException(AbstractResponse $response, Exception $exception): void
+    public function addException(AbstractResponse $response, \Exception $exception): void
     {
         $message = $this->translator->trans($exception->getMessage(), [], 'OneupUploaderBundle');
         $response->addToOffset(['error' => $message], ['files']);

--- a/src/Uploader/ErrorHandler/DropzoneErrorHandler.php
+++ b/src/Uploader/ErrorHandler/DropzoneErrorHandler.php
@@ -4,12 +4,11 @@ declare(strict_types=1);
 
 namespace Oneup\UploaderBundle\Uploader\ErrorHandler;
 
-use Exception;
 use Oneup\UploaderBundle\Uploader\Response\AbstractResponse;
 
 class DropzoneErrorHandler implements ErrorHandlerInterface
 {
-    public function addException(AbstractResponse $response, Exception $exception): void
+    public function addException(AbstractResponse $response, \Exception $exception): void
     {
         $errors[] = $exception;
         $message = $exception->getMessage();

--- a/src/Uploader/ErrorHandler/ErrorHandlerInterface.php
+++ b/src/Uploader/ErrorHandler/ErrorHandlerInterface.php
@@ -4,10 +4,9 @@ declare(strict_types=1);
 
 namespace Oneup\UploaderBundle\Uploader\ErrorHandler;
 
-use Exception;
 use Oneup\UploaderBundle\Uploader\Response\AbstractResponse;
 
 interface ErrorHandlerInterface
 {
-    public function addException(AbstractResponse $response, Exception $exception): void;
+    public function addException(AbstractResponse $response, \Exception $exception): void;
 }

--- a/src/Uploader/ErrorHandler/NoopErrorHandler.php
+++ b/src/Uploader/ErrorHandler/NoopErrorHandler.php
@@ -4,12 +4,11 @@ declare(strict_types=1);
 
 namespace Oneup\UploaderBundle\Uploader\ErrorHandler;
 
-use Exception;
 use Oneup\UploaderBundle\Uploader\Response\AbstractResponse;
 
 class NoopErrorHandler implements ErrorHandlerInterface
 {
-    public function addException(AbstractResponse $response, Exception $exception): void
+    public function addException(AbstractResponse $response, \Exception $exception): void
     {
         // noop
     }

--- a/src/Uploader/ErrorHandler/PluploadErrorHandler.php
+++ b/src/Uploader/ErrorHandler/PluploadErrorHandler.php
@@ -4,12 +4,11 @@ declare(strict_types=1);
 
 namespace Oneup\UploaderBundle\Uploader\ErrorHandler;
 
-use Exception;
 use Oneup\UploaderBundle\Uploader\Response\AbstractResponse;
 
 class PluploadErrorHandler implements ErrorHandlerInterface
 {
-    public function addException(AbstractResponse $response, Exception $exception): void
+    public function addException(AbstractResponse $response, \Exception $exception): void
     {
         /* Plupload only needs an error message so it can be handled client side */
         $message = $exception->getMessage();

--- a/src/Uploader/File/FileInterface.php
+++ b/src/Uploader/File/FileInterface.php
@@ -55,8 +55,5 @@ interface FileInterface
      */
     public function getExtension(): string;
 
-    /**
-     * @return mixed
-     */
     public function getFileSystem();
 }

--- a/src/Uploader/File/FlysystemFile.php
+++ b/src/Uploader/File/FlysystemFile.php
@@ -9,10 +9,6 @@ use League\Flysystem\FilesystemOperator;
 
 class FlysystemFile implements FileInterface
 {
-    /**
-     * @param string             $pathname
-     * @param FilesystemOperator $filesystem
-     */
     public function __construct(private string $pathname, private FilesystemOperator $filesystem)
     {
     }

--- a/src/Uploader/File/FlysystemFile.php
+++ b/src/Uploader/File/FlysystemFile.php
@@ -10,10 +10,11 @@ use League\Flysystem\FilesystemOperator;
 class FlysystemFile implements FileInterface
 {
     /**
-     * @param string $pathname
+     * @param string             $pathname
      * @param FilesystemOperator $filesystem
      */
-    public function __construct(private string $pathname, private FilesystemOperator $filesystem) {
+    public function __construct(private string $pathname, private FilesystemOperator $filesystem)
+    {
     }
 
     /**

--- a/src/Uploader/File/FlysystemFile.php
+++ b/src/Uploader/File/FlysystemFile.php
@@ -9,16 +9,11 @@ use League\Flysystem\FilesystemOperator;
 
 class FlysystemFile implements FileInterface
 {
-    /** @var string */
-    private $pathname;
-
-    /** @var FilesystemOperator */
-    private $filesystem;
-
-    public function __construct(string $pathname, FilesystemOperator $filesystem)
-    {
-        $this->pathname = $pathname;
-        $this->filesystem = $filesystem;
+    /**
+     * @param string $pathname
+     * @param FilesystemOperator $filesystem
+     */
+    public function __construct(private string $pathname, private FilesystemOperator $filesystem) {
     }
 
     /**

--- a/src/Uploader/File/GaufretteFile.php
+++ b/src/Uploader/File/GaufretteFile.php
@@ -16,9 +16,6 @@ class GaufretteFile extends File implements FileInterface
      */
     protected $mimeType;
 
-    /**
-     * @param string|null $streamWrapperPrefix
-     */
     public function __construct(File $file, FilesystemInterface $filesystem, protected ?string $streamWrapperPrefix = null)
     {
         parent::__construct($file->getKey(), $filesystem);

--- a/src/Uploader/File/GaufretteFile.php
+++ b/src/Uploader/File/GaufretteFile.php
@@ -17,8 +17,6 @@ class GaufretteFile extends File implements FileInterface
     protected $mimeType;
 
     /**
-     * @param File $file
-     * @param FilesystemInterface $filesystem
      * @param string|null $streamWrapperPrefix
      */
     public function __construct(File $file, FilesystemInterface $filesystem, protected ?string $streamWrapperPrefix = null)

--- a/src/Uploader/File/GaufretteFile.php
+++ b/src/Uploader/File/GaufretteFile.php
@@ -12,20 +12,18 @@ use Gaufrette\FilesystemInterface;
 class GaufretteFile extends File implements FileInterface
 {
     /**
-     * @var string|null
-     */
-    protected $streamWrapperPrefix;
-
-    /**
      * @var string
      */
     protected $mimeType;
 
-    public function __construct(File $file, FilesystemInterface $filesystem, string $streamWrapperPrefix = null)
+    /**
+     * @param File $file
+     * @param FilesystemInterface $filesystem
+     * @param string|null $streamWrapperPrefix
+     */
+    public function __construct(File $file, FilesystemInterface $filesystem, protected ?string $streamWrapperPrefix = null)
     {
         parent::__construct($file->getKey(), $filesystem);
-
-        $this->streamWrapperPrefix = $streamWrapperPrefix;
     }
 
     /**

--- a/src/Uploader/Orphanage/OrphanageManager.php
+++ b/src/Uploader/Orphanage/OrphanageManager.php
@@ -12,20 +12,8 @@ use Symfony\Component\Finder\Finder;
 
 class OrphanageManager
 {
-    /**
-     * @var ContainerInterface
-     */
-    protected $container;
 
-    /**
-     * @var array
-     */
-    protected $config;
-
-    public function __construct(ContainerInterface $container, array $config)
-    {
-        $this->container = $container;
-        $this->config = $config;
+    public function __construct(protected ContainerInterface $container, protected array $config) {
     }
 
     public function has(string $key): bool

--- a/src/Uploader/Orphanage/OrphanageManager.php
+++ b/src/Uploader/Orphanage/OrphanageManager.php
@@ -12,8 +12,8 @@ use Symfony\Component\Finder\Finder;
 
 class OrphanageManager
 {
-
-    public function __construct(protected ContainerInterface $container, protected array $config) {
+    public function __construct(protected ContainerInterface $container, protected array $config)
+    {
     }
 
     public function has(string $key): bool

--- a/src/Uploader/Response/AbstractResponse.php
+++ b/src/Uploader/Response/AbstractResponse.php
@@ -6,41 +6,26 @@ namespace Oneup\UploaderBundle\Uploader\Response;
 
 abstract class AbstractResponse implements \ArrayAccess, ResponseInterface
 {
-    /**
-     * @param array $data
-     */
     public function __construct(protected array $data = [])
     {
     }
 
-    /**
-     * @param mixed $offset
-     * @param mixed $value
-     */
     public function offsetSet($offset, $value): void
     {
         null === $offset ? $this->data[] = $value : $this->data[$offset] = $value;
     }
 
-    /**
-     * @param mixed $offset
-     */
     public function offsetExists($offset): bool
     {
         return isset($this->data[$offset]);
     }
 
-    /**
-     * @param mixed $offset
-     */
     public function offsetUnset($offset): void
     {
         unset($this->data[$offset]);
     }
 
     /**
-     * @param mixed $offset
-     *
      * @return mixed|null
      */
     #[\ReturnTypeWillChange]
@@ -52,8 +37,6 @@ abstract class AbstractResponse implements \ArrayAccess, ResponseInterface
     /**
      * The \ArrayAccess interface does not support multi-dimensional array syntax such as $array["foo"][] = bar
      * This function will take a path of arrays and add a new element to it, creating the path if needed.
-     *
-     * @param mixed $value
      *
      * @throws \InvalidArgumentException if the path contains non-array items
      */

--- a/src/Uploader/Response/AbstractResponse.php
+++ b/src/Uploader/Response/AbstractResponse.php
@@ -7,13 +7,9 @@ namespace Oneup\UploaderBundle\Uploader\Response;
 abstract class AbstractResponse implements \ArrayAccess, ResponseInterface
 {
     /**
-     * @var array
+     * @param array $data
      */
-    protected $data;
-
-    public function __construct()
-    {
-        $this->data = [];
+    public function __construct(protected array $data = []){
     }
 
     /**

--- a/src/Uploader/Response/AbstractResponse.php
+++ b/src/Uploader/Response/AbstractResponse.php
@@ -9,7 +9,8 @@ abstract class AbstractResponse implements \ArrayAccess, ResponseInterface
     /**
      * @param array $data
      */
-    public function __construct(protected array $data = []){
+    public function __construct(protected array $data = [])
+    {
     }
 
     /**

--- a/src/Uploader/Response/FineUploaderResponse.php
+++ b/src/Uploader/Response/FineUploaderResponse.php
@@ -7,10 +7,11 @@ namespace Oneup\UploaderBundle\Uploader\Response;
 class FineUploaderResponse extends AbstractResponse
 {
     /**
-     * @param bool $success
+     * @param bool        $success
      * @param string|null $error
      */
-    public function __construct(protected bool $success = true, protected ?string $error = null) {
+    public function __construct(protected bool $success = true, protected ?string $error = null)
+    {
         parent::__construct();
     }
 

--- a/src/Uploader/Response/FineUploaderResponse.php
+++ b/src/Uploader/Response/FineUploaderResponse.php
@@ -6,10 +6,6 @@ namespace Oneup\UploaderBundle\Uploader\Response;
 
 class FineUploaderResponse extends AbstractResponse
 {
-    /**
-     * @param bool        $success
-     * @param string|null $error
-     */
     public function __construct(protected bool $success = true, protected ?string $error = null)
     {
         parent::__construct();

--- a/src/Uploader/Response/FineUploaderResponse.php
+++ b/src/Uploader/Response/FineUploaderResponse.php
@@ -7,27 +7,17 @@ namespace Oneup\UploaderBundle\Uploader\Response;
 class FineUploaderResponse extends AbstractResponse
 {
     /**
-     * @var bool
+     * @param bool $success
+     * @param string|null $error
      */
-    protected $success;
-
-    /**
-     * @var string|null
-     */
-    protected $error;
-
-    public function __construct()
-    {
-        $this->success = true;
-        $this->error = null;
-
+    public function __construct(protected bool $success = true, protected ?string $error = null) {
         parent::__construct();
     }
 
     public function assemble(): array
     {
         // explicitly overwrite success and error key
-        // as these keys are used internaly by the
+        // as these keys are used internally by the
         // frontend uploader
         $data = $this->data;
         $data['success'] = $this->success;

--- a/src/Uploader/Response/MooUploadResponse.php
+++ b/src/Uploader/Response/MooUploadResponse.php
@@ -26,7 +26,8 @@ class MooUploadResponse extends AbstractResponse
      */
     protected $uploadedName;
 
-    public function __construct(protected bool $finish = true, protected int $error = 0) {
+    public function __construct(protected bool $finish = true, protected int $error = 0)
+    {
         parent::__construct();
     }
 

--- a/src/Uploader/Response/MooUploadResponse.php
+++ b/src/Uploader/Response/MooUploadResponse.php
@@ -22,25 +22,11 @@ class MooUploadResponse extends AbstractResponse
     protected $size;
 
     /**
-     * @var int
-     */
-    protected $error;
-
-    /**
-     * @var bool
-     */
-    protected $finish;
-
-    /**
      * @var string
      */
     protected $uploadedName;
 
-    public function __construct()
-    {
-        $this->finish = true;
-        $this->error = 0;
-
+    public function __construct(protected bool $finish = true, protected int $error = 0) {
         parent::__construct();
     }
 

--- a/src/Uploader/Response/MooUploadResponse.php
+++ b/src/Uploader/Response/MooUploadResponse.php
@@ -45,9 +45,6 @@ class MooUploadResponse extends AbstractResponse
         return $data;
     }
 
-    /**
-     * @param mixed $id
-     */
     public function setId($id): self
     {
         $this->id = $id;
@@ -55,9 +52,6 @@ class MooUploadResponse extends AbstractResponse
         return $this;
     }
 
-    /**
-     * @return mixed
-     */
     public function getId()
     {
         return $this->id;
@@ -75,9 +69,6 @@ class MooUploadResponse extends AbstractResponse
         return $this->name;
     }
 
-    /**
-     * @param mixed $size
-     */
     public function setSize($size): self
     {
         $this->size = (int) $size;

--- a/src/Uploader/Storage/FilesystemOrphanageStorage.php
+++ b/src/Uploader/Storage/FilesystemOrphanageStorage.php
@@ -16,42 +16,24 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
 class FilesystemOrphanageStorage extends FilesystemStorage implements OrphanageStorageInterface
 {
     /**
-     * @var StorageInterface
-     */
-    protected $storage;
-
-    /**
      * @var SessionInterface
      */
     protected $session;
 
     /**
-     * @var ChunkStorage
+     * @param StorageInterface $storage
+     * @param RequestStack $requestStack
+     * @param ChunkStorage $chunkStorage
+     * @param array $config
+     * @param string $type
      */
-    protected $chunkStorage;
-
-    /**
-     * @var array
-     */
-    protected $config;
-
-    /**
-     * @var string
-     */
-    protected $type;
-
-    public function __construct(StorageInterface $storage, RequestStack $requestStack, ChunkStorage $chunkStorage, array $config, string $type)
+    public function __construct(protected StorageInterface $storage, RequestStack $requestStack, protected ChunkStorage $chunkStorage, protected array $config, protected string $type)
     {
         parent::__construct($config['directory']);
 
         /** @var Request $request */
         $request = $requestStack->getCurrentRequest();
-
-        $this->storage = $storage;
         $this->session = $request->getSession();
-        $this->chunkStorage = $chunkStorage;
-        $this->config = $config;
-        $this->type = $type;
     }
 
     /**

--- a/src/Uploader/Storage/FilesystemOrphanageStorage.php
+++ b/src/Uploader/Storage/FilesystemOrphanageStorage.php
@@ -22,10 +22,9 @@ class FilesystemOrphanageStorage extends FilesystemStorage implements OrphanageS
 
     /**
      * @param StorageInterface $storage
-     * @param RequestStack $requestStack
-     * @param ChunkStorage $chunkStorage
-     * @param array $config
-     * @param string $type
+     * @param ChunkStorage     $chunkStorage
+     * @param array            $config
+     * @param string           $type
      */
     public function __construct(protected StorageInterface $storage, RequestStack $requestStack, protected ChunkStorage $chunkStorage, protected array $config, protected string $type)
     {

--- a/src/Uploader/Storage/FilesystemOrphanageStorage.php
+++ b/src/Uploader/Storage/FilesystemOrphanageStorage.php
@@ -20,12 +20,6 @@ class FilesystemOrphanageStorage extends FilesystemStorage implements OrphanageS
      */
     protected $session;
 
-    /**
-     * @param StorageInterface $storage
-     * @param ChunkStorage     $chunkStorage
-     * @param array            $config
-     * @param string           $type
-     */
     public function __construct(protected StorageInterface $storage, RequestStack $requestStack, protected ChunkStorage $chunkStorage, protected array $config, protected string $type)
     {
         parent::__construct($config['directory']);
@@ -61,7 +55,8 @@ class FilesystemOrphanageStorage extends FilesystemStorage implements OrphanageS
             foreach ($files as $file) {
                 $return[] = $this->storage->upload(
                     new FilesystemFile(new File($file->getPathname())),
-                    ltrim(str_replace($this->getFindPath(), '', (string) $file), '/'));
+                    ltrim(str_replace($this->getFindPath(), '', (string) $file), '/')
+                );
             }
 
             return $return;
@@ -77,10 +72,10 @@ class FilesystemOrphanageStorage extends FilesystemStorage implements OrphanageS
         try {
             $finder->in($this->getFindPath())->files();
         } catch (\InvalidArgumentException $e) {
-            //catch non-existing directory exception.
-            //This can happen if getFiles is called and no file has yet been uploaded
+            // catch non-existing directory exception.
+            // This can happen if getFiles is called and no file has yet been uploaded
 
-            //push empty array into the finder so we can emulate no files found
+            // push empty array into the finder so we can emulate no files found
             $finder->append([]);
         }
 

--- a/src/Uploader/Storage/FilesystemStorage.php
+++ b/src/Uploader/Storage/FilesystemStorage.php
@@ -11,13 +11,9 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 class FilesystemStorage implements StorageInterface
 {
     /**
-     * @var string
+     * @param string $directory
      */
-    protected $directory;
-
-    public function __construct(string $directory)
-    {
-        $this->directory = $directory;
+    public function __construct(protected string $directory){
     }
 
     /**

--- a/src/Uploader/Storage/FilesystemStorage.php
+++ b/src/Uploader/Storage/FilesystemStorage.php
@@ -13,7 +13,8 @@ class FilesystemStorage implements StorageInterface
     /**
      * @param string $directory
      */
-    public function __construct(protected string $directory){
+    public function __construct(protected string $directory)
+    {
     }
 
     /**

--- a/src/Uploader/Storage/FilesystemStorage.php
+++ b/src/Uploader/Storage/FilesystemStorage.php
@@ -10,9 +10,6 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class FilesystemStorage implements StorageInterface
 {
-    /**
-     * @param string $directory
-     */
     public function __construct(protected string $directory)
     {
     }

--- a/src/Uploader/Storage/FlysystemOrphanageStorage.php
+++ b/src/Uploader/Storage/FlysystemOrphanageStorage.php
@@ -23,10 +23,9 @@ class FlysystemOrphanageStorage extends FlysystemStorage implements OrphanageSto
 
     /**
      * @param StorageInterface $storage
-     * @param RequestStack $requestStack
-     * @param ChunkStorage $chunkStorage
-     * @param array $config
-     * @param string $type
+     * @param ChunkStorage     $chunkStorage
+     * @param array            $config
+     * @param string           $type
      */
     public function __construct(protected StorageInterface $storage, RequestStack $requestStack, protected ChunkStorage $chunkStorage, protected array $config, protected string $type)
     {

--- a/src/Uploader/Storage/FlysystemOrphanageStorage.php
+++ b/src/Uploader/Storage/FlysystemOrphanageStorage.php
@@ -21,12 +21,6 @@ class FlysystemOrphanageStorage extends FlysystemStorage implements OrphanageSto
      */
     protected $session;
 
-    /**
-     * @param StorageInterface $storage
-     * @param ChunkStorage     $chunkStorage
-     * @param array            $config
-     * @param string           $type
-     */
     public function __construct(protected StorageInterface $storage, RequestStack $requestStack, protected ChunkStorage $chunkStorage, protected array $config, protected string $type)
     {
         /*

--- a/src/Uploader/Storage/FlysystemOrphanageStorage.php
+++ b/src/Uploader/Storage/FlysystemOrphanageStorage.php
@@ -17,31 +17,18 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
 class FlysystemOrphanageStorage extends FlysystemStorage implements OrphanageStorageInterface
 {
     /**
-     * @var StorageInterface
-     */
-    protected $storage;
-
-    /**
      * @var SessionInterface
      */
     protected $session;
 
     /**
-     * @var ChunkStorage
+     * @param StorageInterface $storage
+     * @param RequestStack $requestStack
+     * @param ChunkStorage $chunkStorage
+     * @param array $config
+     * @param string $type
      */
-    protected $chunkStorage;
-
-    /**
-     * @var array
-     */
-    protected $config;
-
-    /**
-     * @var string
-     */
-    protected $type;
-
-    public function __construct(StorageInterface $storage, RequestStack $requestStack, ChunkStorage $chunkStorage, array $config, string $type)
+    public function __construct(protected StorageInterface $storage, RequestStack $requestStack, protected ChunkStorage $chunkStorage, protected array $config, protected string $type)
     {
         /*
          * initiate the storage on the chunk storage's filesystem
@@ -51,12 +38,7 @@ class FlysystemOrphanageStorage extends FlysystemStorage implements OrphanageSto
 
         /** @var Request $request */
         $request = $requestStack->getCurrentRequest();
-
-        $this->storage = $storage;
-        $this->chunkStorage = $chunkStorage;
         $this->session = $request->getSession();
-        $this->config = $config;
-        $this->type = $type;
     }
 
     /**

--- a/src/Uploader/Storage/FlysystemStorage.php
+++ b/src/Uploader/Storage/FlysystemStorage.php
@@ -14,11 +14,6 @@ use Symfony\Component\HttpFoundation\File\File as SymfonyFile;
 
 class FlysystemStorage implements StorageInterface
 {
-    /**
-     * @param FilesystemOperator $filesystem
-     * @param int                $bufferSize
-     * @param string|null        $streamWrapperPrefix
-     */
     public function __construct(private FilesystemOperator $filesystem, protected int $bufferSize, protected ?string $streamWrapperPrefix = null)
     {
     }

--- a/src/Uploader/Storage/FlysystemStorage.php
+++ b/src/Uploader/Storage/FlysystemStorage.php
@@ -15,25 +15,11 @@ use Symfony\Component\HttpFoundation\File\File as SymfonyFile;
 class FlysystemStorage implements StorageInterface
 {
     /**
-     * @var string|null
+     * @param FilesystemOperator $filesystem
+     * @param int $bufferSize
+     * @param string|null $streamWrapperPrefix
      */
-    protected $streamWrapperPrefix;
-
-    /**
-     * @var int
-     */
-    protected $bufferSize;
-
-    /**
-     * @var FilesystemOperator
-     */
-    private $filesystem;
-
-    public function __construct(FilesystemOperator $filesystem, int $bufferSize, ?string $streamWrapperPrefix = null)
-    {
-        $this->filesystem = $filesystem;
-        $this->bufferSize = $bufferSize;
-        $this->streamWrapperPrefix = $streamWrapperPrefix;
+    public function __construct(private FilesystemOperator $filesystem, protected int $bufferSize, protected ?string $streamWrapperPrefix = null) {
     }
 
     /**

--- a/src/Uploader/Storage/FlysystemStorage.php
+++ b/src/Uploader/Storage/FlysystemStorage.php
@@ -16,10 +16,11 @@ class FlysystemStorage implements StorageInterface
 {
     /**
      * @param FilesystemOperator $filesystem
-     * @param int $bufferSize
-     * @param string|null $streamWrapperPrefix
+     * @param int                $bufferSize
+     * @param string|null        $streamWrapperPrefix
      */
-    public function __construct(private FilesystemOperator $filesystem, protected int $bufferSize, protected ?string $streamWrapperPrefix = null) {
+    public function __construct(private FilesystemOperator $filesystem, protected int $bufferSize, protected ?string $streamWrapperPrefix = null)
+    {
     }
 
     /**

--- a/src/Uploader/Storage/GaufretteOrphanageStorage.php
+++ b/src/Uploader/Storage/GaufretteOrphanageStorage.php
@@ -19,12 +19,6 @@ class GaufretteOrphanageStorage extends GaufretteStorage implements OrphanageSto
      */
     protected $session;
 
-    /**
-     * @param StorageInterface      $storage
-     * @param GaufretteChunkStorage $chunkStorage
-     * @param array                 $config
-     * @param string                $type
-     */
     public function __construct(protected StorageInterface $storage, RequestStack $requestStack, protected GaufretteChunkStorage $chunkStorage, protected array $config, protected string $type)
     {
         /*

--- a/src/Uploader/Storage/GaufretteOrphanageStorage.php
+++ b/src/Uploader/Storage/GaufretteOrphanageStorage.php
@@ -20,11 +20,10 @@ class GaufretteOrphanageStorage extends GaufretteStorage implements OrphanageSto
     protected $session;
 
     /**
-     * @param StorageInterface $storage
-     * @param RequestStack $requestStack
+     * @param StorageInterface      $storage
      * @param GaufretteChunkStorage $chunkStorage
-     * @param array $config
-     * @param string $type
+     * @param array                 $config
+     * @param string                $type
      */
     public function __construct(protected StorageInterface $storage, RequestStack $requestStack, protected GaufretteChunkStorage $chunkStorage, protected array $config, protected string $type)
     {

--- a/src/Uploader/Storage/GaufretteOrphanageStorage.php
+++ b/src/Uploader/Storage/GaufretteOrphanageStorage.php
@@ -15,31 +15,18 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
 class GaufretteOrphanageStorage extends GaufretteStorage implements OrphanageStorageInterface
 {
     /**
-     * @var StorageInterface
-     */
-    protected $storage;
-
-    /**
      * @var SessionInterface
      */
     protected $session;
 
     /**
-     * @var GaufretteChunkStorage
+     * @param StorageInterface $storage
+     * @param RequestStack $requestStack
+     * @param GaufretteChunkStorage $chunkStorage
+     * @param array $config
+     * @param string $type
      */
-    protected $chunkStorage;
-
-    /**
-     * @var array
-     */
-    protected $config;
-
-    /**
-     * @var string
-     */
-    protected $type;
-
-    public function __construct(StorageInterface $storage, RequestStack $requestStack, GaufretteChunkStorage $chunkStorage, array $config, string $type)
+    public function __construct(protected StorageInterface $storage, RequestStack $requestStack, protected GaufretteChunkStorage $chunkStorage, protected array $config, protected string $type)
     {
         /*
          * initiate the storage on the chunk storage's filesystem
@@ -49,12 +36,7 @@ class GaufretteOrphanageStorage extends GaufretteStorage implements OrphanageSto
 
         /** @var Request $request */
         $request = $requestStack->getCurrentRequest();
-
-        $this->storage = $storage;
-        $this->chunkStorage = $chunkStorage;
         $this->session = $request->getSession();
-        $this->config = $config;
-        $this->type = $type;
     }
 
     /**

--- a/src/Uploader/Storage/GaufretteStorage.php
+++ b/src/Uploader/Storage/GaufretteStorage.php
@@ -15,11 +15,9 @@ use Symfony\Component\Filesystem\Filesystem as LocalFilesystem;
 class GaufretteStorage extends StreamManager implements StorageInterface
 {
     /**
-     * @param FilesystemInterface $filesystem
-     * @param int $bufferSize
      * @param string|null $streamWrapperPrefix
      */
-    public function __construct(FilesystemInterface $filesystem, int $bufferSize, protected  ?string $streamWrapperPrefix = null)
+    public function __construct(FilesystemInterface $filesystem, int $bufferSize, protected ?string $streamWrapperPrefix = null)
     {
         $base = interface_exists(FilesystemInterface::class)
             ? FilesystemInterface::class

--- a/src/Uploader/Storage/GaufretteStorage.php
+++ b/src/Uploader/Storage/GaufretteStorage.php
@@ -14,9 +14,6 @@ use Symfony\Component\Filesystem\Filesystem as LocalFilesystem;
 
 class GaufretteStorage extends StreamManager implements StorageInterface
 {
-    /**
-     * @param string|null $streamWrapperPrefix
-     */
     public function __construct(FilesystemInterface $filesystem, int $bufferSize, protected ?string $streamWrapperPrefix = null)
     {
         $base = interface_exists(FilesystemInterface::class)
@@ -24,7 +21,7 @@ class GaufretteStorage extends StreamManager implements StorageInterface
             : Filesystem::class;
 
         if (!$filesystem instanceof $base) {
-            throw new \InvalidArgumentException(sprintf('Expected an instance of "%s", got "%s".', $base, \get_class($filesystem)));
+            throw new \InvalidArgumentException(sprintf('Expected an instance of "%s", got "%s".', $base, $filesystem::class));
         }
 
         $this->filesystem = $filesystem;

--- a/src/Uploader/Storage/GaufretteStorage.php
+++ b/src/Uploader/Storage/GaufretteStorage.php
@@ -15,11 +15,11 @@ use Symfony\Component\Filesystem\Filesystem as LocalFilesystem;
 class GaufretteStorage extends StreamManager implements StorageInterface
 {
     /**
-     * @var string|null
+     * @param FilesystemInterface $filesystem
+     * @param int $bufferSize
+     * @param string|null $streamWrapperPrefix
      */
-    protected $streamWrapperPrefix;
-
-    public function __construct(FilesystemInterface $filesystem, int $bufferSize, ?string $streamWrapperPrefix = null)
+    public function __construct(FilesystemInterface $filesystem, int $bufferSize, protected  ?string $streamWrapperPrefix = null)
     {
         $base = interface_exists(FilesystemInterface::class)
             ? FilesystemInterface::class
@@ -31,7 +31,6 @@ class GaufretteStorage extends StreamManager implements StorageInterface
 
         $this->filesystem = $filesystem;
         $this->buffersize = $bufferSize;
-        $this->streamWrapperPrefix = $streamWrapperPrefix;
     }
 
     /**

--- a/tests/Controller/AbstractUploadTest.php
+++ b/tests/Controller/AbstractUploadTest.php
@@ -87,8 +87,5 @@ abstract class AbstractUploadTest extends AbstractControllerTest
 
     abstract protected function getRequestParameters(): array;
 
-    /**
-     * @return mixed
-     */
     abstract protected function getRequestFile();
 }

--- a/tests/Controller/AbstractValidationTest.php
+++ b/tests/Controller/AbstractValidationTest.php
@@ -6,6 +6,7 @@ namespace Oneup\UploaderBundle\Tests\Controller;
 
 use Oneup\UploaderBundle\Event\ValidationEvent;
 use Psr\Container\ContainerInterface;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 abstract class AbstractValidationTest extends AbstractControllerTest
 {
@@ -118,13 +119,13 @@ abstract class AbstractValidationTest extends AbstractControllerTest
         $this->assertCount(0, $this->getUploadedFiles());
     }
 
-    abstract protected function getFileWithCorrectMimeType();
+    abstract protected function getFileWithCorrectMimeType(): UploadedFile;
 
-    abstract protected function getFileWithCorrectMimeTypeAndIncorrectExtension();
+    abstract protected function getFileWithCorrectMimeTypeAndIncorrectExtension(): UploadedFile;
 
-    abstract protected function getFileWithIncorrectMimeType();
+    abstract protected function getFileWithIncorrectMimeType(): UploadedFile;
 
-    abstract protected function getOversizedFile();
+    abstract protected function getOversizedFile(): UploadedFile;
 
     abstract protected function getRequestParameters(): array;
 }

--- a/tests/Controller/AbstractValidationTest.php
+++ b/tests/Controller/AbstractValidationTest.php
@@ -18,7 +18,7 @@ abstract class AbstractValidationTest extends AbstractControllerTest
         $client->request('POST', $endpoint, $this->getRequestParameters(), [$this->getOversizedFile()], $this->requestHeaders);
         $response = $client->getResponse();
 
-        //$this->assertTrue($response->isNotSuccessful());
+        // $this->assertTrue($response->isNotSuccessful());
         $this->assertSame($response->headers->get('Content-Type'), 'application/json');
         $this->assertCount(0, $this->getUploadedFiles());
     }
@@ -113,29 +113,17 @@ abstract class AbstractValidationTest extends AbstractControllerTest
         $client->request('POST', $endpoint, $this->getRequestParameters(), [$this->getFileWithIncorrectMimeType()], $this->requestHeaders);
         $response = $client->getResponse();
 
-        //$this->assertTrue($response->isNotSuccessful());
+        // $this->assertTrue($response->isNotSuccessful());
         $this->assertSame($response->headers->get('Content-Type'), 'application/json');
         $this->assertCount(0, $this->getUploadedFiles());
     }
 
-    /**
-     * @return mixed
-     */
     abstract protected function getFileWithCorrectMimeType();
 
-    /**
-     * @return mixed
-     */
     abstract protected function getFileWithCorrectMimeTypeAndIncorrectExtension();
 
-    /**
-     * @return mixed
-     */
     abstract protected function getFileWithIncorrectMimeType();
 
-    /**
-     * @return mixed
-     */
     abstract protected function getOversizedFile();
 
     abstract protected function getRequestParameters(): array;

--- a/tests/Controller/BlueimpTest.php
+++ b/tests/Controller/BlueimpTest.php
@@ -7,6 +7,7 @@ namespace Oneup\UploaderBundle\Tests\Controller;
 use Oneup\UploaderBundle\Event\PostUploadEvent;
 use Oneup\UploaderBundle\Event\PreUploadEvent;
 use Psr\Container\ContainerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\File\File;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
@@ -53,6 +54,7 @@ class BlueimpTest extends AbstractUploadTest
         $container = $client->getContainer();
 
         $endpoint = $this->helper->endpoint($this->getConfigKey());
+        /** @var EventDispatcher $dispatcher */
         $dispatcher = $container->get('event_dispatcher');
 
         // event data

--- a/tests/Controller/BlueimpValidationTest.php
+++ b/tests/Controller/BlueimpValidationTest.php
@@ -21,7 +21,7 @@ class BlueimpValidationTest extends AbstractValidationTest
         $client->request('POST', $endpoint, $this->getRequestParameters(), $this->getOversizedFile(), $this->requestHeaders);
         $response = $client->getResponse();
 
-        //$this->assertTrue($response->isNotSuccessful());
+        // $this->assertTrue($response->isNotSuccessful());
         $this->assertSame($response->headers->get('Content-Type'), 'application/json');
         $this->assertCount(0, $this->getUploadedFiles());
         $this->assertFalse(strpos((string) $response->getContent(), 'error.maxsize'), 'Failed to translate error id into lang');
@@ -78,7 +78,7 @@ class BlueimpValidationTest extends AbstractValidationTest
         $client->request('POST', $endpoint, $this->getRequestParameters(), $this->getFileWithIncorrectMimeType(), $this->requestHeaders);
         $response = $client->getResponse();
 
-        //$this->assertTrue($response->isNotSuccessful());
+        // $this->assertTrue($response->isNotSuccessful());
         $this->assertSame($response->headers->get('Content-Type'), 'application/json');
         $this->assertCount(0, $this->getUploadedFiles());
     }

--- a/tests/Controller/BlueimpValidationTest.php
+++ b/tests/Controller/BlueimpValidationTest.php
@@ -17,8 +17,8 @@ class BlueimpValidationTest extends AbstractValidationTest
         /** @var KernelBrowser $client */
         $client = $this->client;
         $endpoint = $this->helper->endpoint($this->getConfigKey());
-
-        $client->request('POST', $endpoint, $this->getRequestParameters(), $this->getOversizedFile(), $this->requestHeaders);
+        $file = ['files' => [$this->getOversizedFile()]];
+        $client->request('POST', $endpoint, $this->getRequestParameters(), $file, $this->requestHeaders);
         $response = $client->getResponse();
 
         // $this->assertTrue($response->isNotSuccessful());
@@ -43,8 +43,8 @@ class BlueimpValidationTest extends AbstractValidationTest
         $dispatcher->addListener(ValidationEvent::NAME, static function () use (&$validationCount): void {
             ++$validationCount;
         });
-
-        $client->request('POST', $endpoint, $this->getRequestParameters(), $this->getFileWithCorrectMimeType(), $this->requestHeaders);
+        $file = ['files' => [$this->getFileWithCorrectMimeType()]];
+        $client->request('POST', $endpoint, $this->getRequestParameters(), $file, $this->requestHeaders);
 
         $this->assertSame(1, $validationCount);
     }
@@ -54,8 +54,8 @@ class BlueimpValidationTest extends AbstractValidationTest
         // assemble a request
         $client = $this->client;
         $endpoint = $this->helper->endpoint($this->getConfigKey());
-
-        $client->request('POST', $endpoint, $this->getRequestParameters(), $this->getFileWithCorrectMimeType(), $this->requestHeaders);
+        $file = ['files' => [$this->getFileWithCorrectMimeType()]];
+        $client->request('POST', $endpoint, $this->getRequestParameters(), $file, $this->requestHeaders);
         $response = $client->getResponse();
 
         $this->assertTrue($response->isSuccessful());
@@ -74,8 +74,8 @@ class BlueimpValidationTest extends AbstractValidationTest
         // assemble a request
         $client = $this->client;
         $endpoint = $this->helper->endpoint($this->getConfigKey());
-
-        $client->request('POST', $endpoint, $this->getRequestParameters(), $this->getFileWithIncorrectMimeType(), $this->requestHeaders);
+        $file = [$this->getFileWithIncorrectMimeType()];
+        $client->request('POST', $endpoint, $this->getRequestParameters(), $file, $this->requestHeaders);
         $response = $client->getResponse();
 
         // $this->assertTrue($response->isNotSuccessful());
@@ -93,39 +93,39 @@ class BlueimpValidationTest extends AbstractValidationTest
         return [];
     }
 
-    protected function getOversizedFile(): array
+    protected function getOversizedFile(): UploadedFile
     {
-        return ['files' => [new UploadedFile(
+        return new UploadedFile(
             $this->createTempFile(512),
             'cat.ok',
             'text/plain'
-        )]];
+        );
     }
 
-    protected function getFileWithCorrectMimeType(): array
+    protected function getFileWithCorrectMimeType(): UploadedFile
     {
-        return ['files' => [new UploadedFile(
+        return new UploadedFile(
             $this->createTempFile(128),
             'cat.txt',
             'text/plain'
-        )]];
+        );
     }
 
-    protected function getFileWithCorrectMimeTypeAndIncorrectExtension(): array
+    protected function getFileWithCorrectMimeTypeAndIncorrectExtension(): UploadedFile
     {
-        return ['files' => [new UploadedFile(
+        return new UploadedFile(
             $this->createTempFile(128),
             'cat.txxt',
             'text/plain'
-        )]];
+        );
     }
 
-    protected function getFileWithIncorrectMimeType(): array
+    protected function getFileWithIncorrectMimeType(): UploadedFile
     {
-        return [new UploadedFile(
+        return new UploadedFile(
             $this->createTempFile(128),
             'cat.ok',
             'image/gif'
-        )];
+        );
     }
 }

--- a/tests/Controller/DropzoneValidationTest.php
+++ b/tests/Controller/DropzoneValidationTest.php
@@ -18,7 +18,7 @@ class DropzoneValidationTest extends AbstractValidationTest
         return [];
     }
 
-    protected function getOversizedFile()
+    protected function getOversizedFile(): UploadedFile
     {
         return new UploadedFile(
             $this->createTempFile(512),
@@ -27,7 +27,7 @@ class DropzoneValidationTest extends AbstractValidationTest
         );
     }
 
-    protected function getFileWithCorrectMimeType()
+    protected function getFileWithCorrectMimeType(): UploadedFile
     {
         return new UploadedFile(
             $this->createTempFile(128),
@@ -36,7 +36,7 @@ class DropzoneValidationTest extends AbstractValidationTest
         );
     }
 
-    protected function getFileWithCorrectMimeTypeAndIncorrectExtension()
+    protected function getFileWithCorrectMimeTypeAndIncorrectExtension(): UploadedFile
     {
         return new UploadedFile(
             $this->createTempFile(128),
@@ -45,7 +45,7 @@ class DropzoneValidationTest extends AbstractValidationTest
         );
     }
 
-    protected function getFileWithIncorrectMimeType()
+    protected function getFileWithIncorrectMimeType(): UploadedFile
     {
         return new UploadedFile(
             $this->createTempFile(128),

--- a/tests/Controller/FancyUploadValidationTest.php
+++ b/tests/Controller/FancyUploadValidationTest.php
@@ -18,7 +18,7 @@ class FancyUploadValidationTest extends AbstractValidationTest
         return [];
     }
 
-    protected function getOversizedFile()
+    protected function getOversizedFile(): UploadedFile
     {
         return new UploadedFile(
             $this->createTempFile(512),
@@ -27,7 +27,7 @@ class FancyUploadValidationTest extends AbstractValidationTest
         );
     }
 
-    protected function getFileWithCorrectMimeType()
+    protected function getFileWithCorrectMimeType(): UploadedFile
     {
         return new UploadedFile(
             $this->createTempFile(128),
@@ -36,7 +36,7 @@ class FancyUploadValidationTest extends AbstractValidationTest
         );
     }
 
-    protected function getFileWithCorrectMimeTypeAndIncorrectExtension()
+    protected function getFileWithCorrectMimeTypeAndIncorrectExtension(): UploadedFile
     {
         return new UploadedFile(
             $this->createTempFile(128),
@@ -45,7 +45,7 @@ class FancyUploadValidationTest extends AbstractValidationTest
         );
     }
 
-    protected function getFileWithIncorrectMimeType()
+    protected function getFileWithIncorrectMimeType(): UploadedFile
     {
         return new UploadedFile(
             $this->createTempFile(128),

--- a/tests/Controller/FileBagExtractorTest.php
+++ b/tests/Controller/FileBagExtractorTest.php
@@ -83,9 +83,6 @@ class FileBagExtractorTest extends TestCase
         $this->assertCount(3, $result);
     }
 
-    /**
-     * @return mixed
-     */
     protected function invoke(FileBag $bag)
     {
         return $this->method->invoke($this->mock, $bag);

--- a/tests/Controller/FineUploaderValidationTest.php
+++ b/tests/Controller/FineUploaderValidationTest.php
@@ -18,7 +18,7 @@ class FineUploaderValidationTest extends AbstractValidationTest
         return [];
     }
 
-    protected function getOversizedFile()
+    protected function getOversizedFile(): UploadedFile
     {
         return new UploadedFile(
             $this->createTempFile(512),
@@ -27,7 +27,7 @@ class FineUploaderValidationTest extends AbstractValidationTest
         );
     }
 
-    protected function getFileWithCorrectMimeType()
+    protected function getFileWithCorrectMimeType(): UploadedFile
     {
         return new UploadedFile(
             $this->createTempFile(128),
@@ -36,7 +36,7 @@ class FineUploaderValidationTest extends AbstractValidationTest
         );
     }
 
-    protected function getFileWithCorrectMimeTypeAndIncorrectExtension()
+    protected function getFileWithCorrectMimeTypeAndIncorrectExtension(): UploadedFile
     {
         return new UploadedFile(
             $this->createTempFile(128),
@@ -45,7 +45,7 @@ class FineUploaderValidationTest extends AbstractValidationTest
         );
     }
 
-    protected function getFileWithIncorrectMimeType()
+    protected function getFileWithIncorrectMimeType(): UploadedFile
     {
         return new UploadedFile(
             $this->createTempFile(128),

--- a/tests/Controller/PluploadValidationTest.php
+++ b/tests/Controller/PluploadValidationTest.php
@@ -18,7 +18,7 @@ class PluploadValidationTest extends AbstractValidationTest
         return [];
     }
 
-    protected function getOversizedFile()
+    protected function getOversizedFile(): UploadedFile
     {
         return new UploadedFile(
             $this->createTempFile(512),
@@ -27,7 +27,7 @@ class PluploadValidationTest extends AbstractValidationTest
         );
     }
 
-    protected function getFileWithCorrectMimeType()
+    protected function getFileWithCorrectMimeType(): UploadedFile
     {
         return new UploadedFile(
             $this->createTempFile(128),
@@ -36,7 +36,7 @@ class PluploadValidationTest extends AbstractValidationTest
         );
     }
 
-    protected function getFileWithCorrectMimeTypeAndIncorrectExtension()
+    protected function getFileWithCorrectMimeTypeAndIncorrectExtension(): UploadedFile
     {
         return new UploadedFile(
             $this->createTempFile(128),
@@ -45,7 +45,7 @@ class PluploadValidationTest extends AbstractValidationTest
         );
     }
 
-    protected function getFileWithIncorrectMimeType()
+    protected function getFileWithIncorrectMimeType(): UploadedFile
     {
         return new UploadedFile(
             $this->createTempFile(128),

--- a/tests/Controller/UploadifyValidationTest.php
+++ b/tests/Controller/UploadifyValidationTest.php
@@ -18,7 +18,7 @@ class UploadifyValidationTest extends AbstractValidationTest
         return [];
     }
 
-    protected function getOversizedFile()
+    protected function getOversizedFile(): UploadedFile
     {
         return new UploadedFile(
             $this->createTempFile(512),
@@ -27,7 +27,7 @@ class UploadifyValidationTest extends AbstractValidationTest
         );
     }
 
-    protected function getFileWithCorrectMimeType()
+    protected function getFileWithCorrectMimeType(): UploadedFile
     {
         return new UploadedFile(
             $this->createTempFile(128),
@@ -36,7 +36,7 @@ class UploadifyValidationTest extends AbstractValidationTest
         );
     }
 
-    protected function getFileWithCorrectMimeTypeAndIncorrectExtension()
+    protected function getFileWithCorrectMimeTypeAndIncorrectExtension(): UploadedFile
     {
         return new UploadedFile(
             $this->createTempFile(128),
@@ -45,7 +45,7 @@ class UploadifyValidationTest extends AbstractValidationTest
         );
     }
 
-    protected function getFileWithIncorrectMimeType()
+    protected function getFileWithIncorrectMimeType(): UploadedFile
     {
         return new UploadedFile(
             $this->createTempFile(128),

--- a/tests/DependencyInjection/OneupUploaderExtensionTest.php
+++ b/tests/DependencyInjection/OneupUploaderExtensionTest.php
@@ -76,8 +76,8 @@ class OneupUploaderExtensionTest extends TestCase
         $getValueInBytes->setAccessible(true);
 
         $store = [
-            $getValueInBytes->invoke($mock, ini_get('upload_max_filesize')),
-            $getValueInBytes->invoke($mock, ini_get('post_max_size')),
+            $getValueInBytes->invoke($mock, \ini_get('upload_max_filesize')),
+            $getValueInBytes->invoke($mock, \ini_get('post_max_size')),
         ];
 
         $min = min($store);

--- a/tests/Templating/TemplateHelperTest.php
+++ b/tests/Templating/TemplateHelperTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Oneup\UploaderBundle\Tests\Templating;
 
+use Oneup\UploaderBundle\Templating\Helper\UploaderHelper;
 use Psr\Container\ContainerInterface;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
@@ -20,6 +21,7 @@ class TemplateHelperTest extends WebTestCase
         /** @var ContainerInterface $container */
         $container = $client->getContainer();
 
+        /** @var UploaderHelper $helper */
         $helper = $container->get('oneup_uploader.templating.uploader_helper');
 
         // this is for code coverage

--- a/tests/Uploader/File/FilesystemFileTest.php
+++ b/tests/Uploader/File/FilesystemFileTest.php
@@ -20,7 +20,7 @@ class FilesystemFileTest extends FileTest
         $this->basename = 'test_file.txt';
         $this->pathname = $this->path . '/' . $this->basename;
         $this->extension = 'txt';
-        $this->size = 9; //something = 9 bytes
+        $this->size = 9; // something = 9 bytes
         $this->mimeType = 'text/plain';
 
         file_put_contents($this->pathname, 'something');

--- a/tests/Uploader/File/GaufretteFileTest.php
+++ b/tests/Uploader/File/GaufretteFileTest.php
@@ -31,7 +31,7 @@ class GaufretteFileTest extends FileTest
         $this->basename = 'test_file.txt';
         $this->pathname = $this->path . '/' . $this->basename;
         $this->extension = 'txt';
-        $this->size = 9; //something = 9 bytes
+        $this->size = 9; // something = 9 bytes
         $this->mimeType = 'text/plain';
 
         file_put_contents(sys_get_temp_dir() . '/' . $this->pathname, 'something');

--- a/tests/Uploader/Naming/UrlSafeNamerTest.php
+++ b/tests/Uploader/Naming/UrlSafeNamerTest.php
@@ -22,7 +22,7 @@ class UrlSafeNamerTest extends FileTest
         $this->basename = 'test_file.txt';
         $this->pathname = $this->path . '/' . $this->basename;
         $this->extension = 'txt';
-        $this->size = 9; //something = 9 bytes
+        $this->size = 9; // something = 9 bytes
         $this->mimeType = 'text/plain';
 
         file_put_contents($this->pathname, 'something');

--- a/tests/Uploader/Storage/FlysystemOrphanageStorageTest.php
+++ b/tests/Uploader/Storage/FlysystemOrphanageStorageTest.php
@@ -81,7 +81,7 @@ class FlysystemOrphanageStorageTest extends OrphanageTest
             fwrite($pointer, str_repeat('A', 1024), 1024);
             fclose($pointer);
 
-            //file key needs to be relative to the root of the flysystem filesystem
+            // file key needs to be relative to the root of the flysystem filesystem
             // It seems that tempnam on OS X prepends 'private' to chunkDirectory, so strip that off as well
             $fileKey = str_replace([$this->realDirectory, '/private'], '', $file);
 

--- a/tests/Uploader/Storage/GaufretteAmazonS3StorageTest.php
+++ b/tests/Uploader/Storage/GaufretteAmazonS3StorageTest.php
@@ -42,9 +42,9 @@ class GaufretteAmazonS3StorageTest extends TestCase
     protected function setUp(): void
     {
         if (
-            false === getenv('AWS_ACCESS_KEY_ID') ||
-            false === getenv('AWS_SECRET_ACCESS_KEY') ||
-            false === getenv('AWS_BUCKET')
+            false === getenv('AWS_ACCESS_KEY_ID')
+            || false === getenv('AWS_SECRET_ACCESS_KEY')
+            || false === getenv('AWS_BUCKET')
         ) {
             $this->markTestSkipped('Missing AWS_* ENV variables.');
         }

--- a/tests/Uploader/Storage/GaufretteOrphanageStorageTest.php
+++ b/tests/Uploader/Storage/GaufretteOrphanageStorageTest.php
@@ -81,7 +81,7 @@ class GaufretteOrphanageStorageTest extends OrphanageTest
             fwrite($pointer, str_repeat('A', 1024), 1024);
             fclose($pointer);
 
-            //gaufrette needs the key relative to it's root
+            // gaufrette needs the key relative to it's root
             $fileKey = str_replace($this->realDirectory, '', $file);
 
             $this->payloads[] = new GaufretteFile(new File($fileKey, $filesystem), $filesystem);
@@ -134,6 +134,6 @@ class GaufretteOrphanageStorageTest extends OrphanageTest
 
     public function checkIfTempnameMatchesAfterCreation(): bool
     {
-        return 0 === strpos((string) @tempnam($this->chunkDirectory, 'uploader'), $this->chunkDirectory);
+        return str_starts_with((string) @tempnam($this->chunkDirectory, 'uploader'), $this->chunkDirectory);
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 if (!($loader = @include __DIR__ . '/../vendor/autoload.php')) {
     echo <<<'EOT'
-You need to install the project dependencies using Composer:
-$ wget http://getcomposer.org/composer.phar
-OR
-$ curl -s https://getcomposer.org/installer | php
-$ php composer.phar install --dev
-$ phpunit
-EOT;
+        You need to install the project dependencies using Composer:
+        $ wget https://getcomposer.org/composer.phar
+        OR
+        $ curl -s https://getcomposer.org/installer | php
+        $ php composer.phar install --dev
+        $ phpunit
+        EOT;
     exit(1);
 }


### PR DESCRIPTION
1. Implemented the AsCommand attributes for final $defaultName
3. Removed support for PHP <8.0
4. Reworked the __construct methods to be on-par with php >=8.0
5. Removed all rferences to GetMasterRequest - using only getMainRequest now
6. Fixed custom_uploader.md documentation to use getMainRequest


We might need to bump the major package version due to dropping php v7 support with these changes