### PR TITLE
Remove a deprecation under PHP 8.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.0, 8.1, 8.2, 8.5]
+        php: [8.0, 8.1, 8.2, 8.3, 8.4, 8.5]
         symfony: [5.4, 6.0, 6.1, 6.2, 6.3, 6.4, 7.0]
         exclude:
           - php: 8.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.0, 8.1, 8.2]
+        php: [8.0, 8.1, 8.2, 8.5]
         symfony: [5.4, 6.0, 6.1, 6.2, 6.3, 6.4, 7.0]
         exclude:
           - php: 8.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,30 @@ jobs:
             symfony: 7.0
           - php: 8.1
             symfony: 7.0
+          - php: 8.4
+            symfony: 5.4
+          - php: 8.4
+            symfony: 6.0
+          - php: 8.4
+            symfony: 6.1
+          - php: 8.4
+            symfony: 6.2
+          - php: 8.4
+            symfony: 6.3
+          - php: 8.4
+            symfony: 6.4
+          - php: 8.5
+            symfony: 5.4
+          - php: 8.5
+            symfony: 6.0
+          - php: 8.5
+            symfony: 6.1
+          - php: 8.5
+            symfony: 6.2
+          - php: 8.5
+            symfony: 6.3
+          - php: 8.5
+            symfony: 6.4
     steps:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,7 +4,7 @@
     <php>
         <server name="KERNEL_DIR" value="tests/App" />
         <server name="KERNEL_CLASS" value="Kernel" />
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[total]=999999&amp;verbose=1" />
     </php>
 
     <listeners>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,7 +4,7 @@
     <php>
         <server name="KERNEL_DIR" value="tests/App" />
         <server name="KERNEL_CLASS" value="Kernel" />
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled=1" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak" />
     </php>
 
     <listeners>

--- a/src/Controller/AbstractController.php
+++ b/src/Controller/AbstractController.php
@@ -80,24 +80,26 @@ abstract class AbstractController
     protected function getFiles(FileBag $bag): array
     {
         $files = [];
-        $fileBag = $bag->all();
-        
-        // Ensure we have an array, not an object, to avoid PHP 8.5 deprecation
-        if (!\is_array($fileBag)) {
-            $fileBag = iterator_to_array($fileBag);
-        }
-        
-        $fileIterator = new \RecursiveIteratorIterator(new \RecursiveArrayIterator($fileBag), \RecursiveIteratorIterator::SELF_FIRST);
-
-        foreach ($fileIterator as $file) {
-            if (\is_array($file) || null === $file) {
-                continue;
-            }
-
-            $files[] = $file;
-        }
+        $this->extractFiles($bag->all(), $files);
 
         return $files;
+    }
+
+    /**
+     * Recursively extracts files from a nested array structure.
+     *
+     * @param mixed $data  The data to extract files from
+     * @param array $files The array to collect files into (passed by reference)
+     */
+    private function extractFiles(mixed $data, array &$files): void
+    {
+        if (\is_array($data)) {
+            foreach ($data as $item) {
+                $this->extractFiles($item, $files);
+            }
+        } elseif (null !== $data) {
+            $files[] = $data;
+        }
     }
 
     /**

--- a/src/Controller/AbstractController.php
+++ b/src/Controller/AbstractController.php
@@ -81,6 +81,12 @@ abstract class AbstractController
     {
         $files = [];
         $fileBag = $bag->all();
+        
+        // Ensure we have an array, not an object, to avoid PHP 8.5 deprecation
+        if (!\is_array($fileBag)) {
+            $fileBag = iterator_to_array($fileBag);
+        }
+        
         $fileIterator = new \RecursiveIteratorIterator(new \RecursiveArrayIterator($fileBag), \RecursiveIteratorIterator::SELF_FIRST);
 
         foreach ($fileIterator as $file) {

--- a/src/Controller/AbstractController.php
+++ b/src/Controller/AbstractController.php
@@ -86,23 +86,6 @@ abstract class AbstractController
     }
 
     /**
-     * Recursively extracts files from a nested array structure.
-     *
-     * @param mixed $data  The data to extract files from
-     * @param array $files The array to collect files into (passed by reference)
-     */
-    private function extractFiles(mixed $data, array &$files): void
-    {
-        if (\is_array($data)) {
-            foreach ($data as $item) {
-                $this->extractFiles($item, $files);
-            }
-        } elseif (null !== $data) {
-            $files[] = $data;
-        }
-    }
-
-    /**
      *  This internal function handles the actual upload process
      *  and will most likely be called from the upload()
      *  function in the implemented Controller.
@@ -211,5 +194,22 @@ abstract class AbstractController
 
         $dispatcher->dispatch($event, $eventName);
         $dispatcher->dispatch($event, \sprintf('%s.%s', $eventName, $this->type));
+    }
+
+    /**
+     * Recursively extracts files from a nested array structure.
+     *
+     * @param mixed $data  The data to extract files from
+     * @param array $files The array to collect files into (passed by reference)
+     */
+    private function extractFiles(mixed $data, array &$files): void
+    {
+        if (\is_array($data)) {
+            foreach ($data as $item) {
+                $this->extractFiles($item, $files);
+            }
+        } elseif (null !== $data) {
+            $files[] = $data;
+        }
     }
 }


### PR DESCRIPTION
See https://github.com/1up-lab/OneupUploaderBundle/issues/447

I was able to replicate on PHP 8.5 when enabling the deprecation notices in PHPUNIT:

https://github.com/1up-lab/OneupUploaderBundle/actions/runs/20812002250/job/59778283160?pr=448

```
  83x: ArrayIterator::__construct(): Using an object as a backing array for ArrayIterator is deprecated, as it allows violating class constraints and invariants
    6x in FineUploaderTest::testChunkedUpload from Oneup\UploaderBundle\Tests\Controller
    6x in FineUploaderTest::testEvents from Oneup\UploaderBundle\Tests\Controller
    6x in PluploadTest::testChunkedUpload from Oneup\UploaderBundle\Tests\Controller
    6x in PluploadTest::testEvents from Oneup\UploaderBundle\Tests\Controller
    3x in FileBagExtractorTest::testWithMultipleFiles from Oneup\UploaderBundle\Tests\Controller
```

I wasn't able to make it work with iterators so using arrays with recursion instead: https://github.com/1up-lab/OneupUploaderBundle/pull/448