### PR TITLE
Fix chunk FilesystemStorage sort callback to return int comparator

### DIFF
--- a/src/Uploader/Chunk/Storage/FilesystemStorage.php
+++ b/src/Uploader/Chunk/Storage/FilesystemStorage.php
@@ -116,13 +116,13 @@ class FilesystemStorage implements ChunkStorageInterface
 
         $finder = new Finder();
         $finder
-            ->in(\sprintf('%s/%s', $this->directory, $uuid))->files()->sort(static function (\SplFileInfo $a, \SplFileInfo $b) {
+            ->in(\sprintf('%s/%s', $this->directory, $uuid))->files()->sort(static function (\SplFileInfo $a, \SplFileInfo $b): int {
                 $t = explode('_', $a->getBasename());
                 $s = explode('_', $b->getBasename());
                 $t = (int) $t[0];
                 $s = (int) $s[0];
 
-                return $s < $t;
+                return $t <=> $s;
             });
 
         return $finder;


### PR DESCRIPTION
Fixes a PHP 8.2+ deprecation warning:

"Deprecated: uasort(): Returning bool from comparison function is deprecated..."

The issue occurred in `FilesystemStorage::getChunks()`, where the sort callback returned a boolean.
The comparator now returns an integer using the `<=>` operator, which has been supported since PHP 7.

This change is backward compatible and safe for all PHP versions currently supported in `main` branch.

Reference:
- PHP deprecation announcement: https://www.php.net/manual/en/migration80.deprecated.php#migration80.deprecated.standard